### PR TITLE
Fix comment typo in auto-form

### DIFF
--- a/packages/vitnode/src/lib/helpers/auto-form.ts
+++ b/packages/vitnode/src/lib/helpers/auto-form.ts
@@ -63,7 +63,7 @@ export const getBaseType = (schema: z.ZodTypeAny): string => {
 };
 
 /**
- * Search for a "ZodDefult" in the Zod stack and return its value.
+ * Search for a "ZodDefault" in the Zod stack and return its value.
  */
 export function getDefaultValueInZodStack(schema: z.ZodTypeAny): unknown {
   if (schema._def.typeName === z.ZodFirstPartyTypeKind.ZodDefault) {


### PR DESCRIPTION
## Summary
- correct `ZodDefault` spelling in auto-form helper comment

## Testing
- `pnpm test` *(fails: vitest not found because dependencies are missing)*

------
https://chatgpt.com/codex/tasks/task_e_68409cd23c4c8324b3c0ea53f22e4edc