### PR TITLE
Remove explicit plugin IDs from API builders

### DIFF
--- a/apps/docs/content/docs/dev/api/modules.mdx
+++ b/apps/docs/content/docs/dev/api/modules.mdx
@@ -10,10 +10,8 @@ Think of modules as containers for related API endpoints. They help organize you
 ```ts title="plugins/blog/src/api/modules/categories/categories.module.ts"
 import { buildModule } from "@vitnode/core/api/lib/module";
 
-import { CONFIG_PLUGIN } from "@/config";
 
 export const categoriesModule = buildModule({
-  pluginId: CONFIG_PLUGIN.id,
   name: "categories",
   routes: [] // We'll populate this soon!
 });
@@ -26,12 +24,10 @@ Want to create a module hierarchy? VitNode's got your back! Nested modules are p
 ```ts title="plugins/blog/src/api/modules/categories/categories.module.ts"
 import { buildModule } from "@vitnode/core/api/lib/module";
 
-import { CONFIG_PLUGIN } from "@/config";
 
 import { postsModule } from "./posts/posts.module"; // [!code ++]
 
 export const categoriesModule = buildModule({
-  pluginId: CONFIG_PLUGIN.id,
   name: "categories",
   routes: [],
   modules: [postsModule] // [!code ++]
@@ -45,14 +41,12 @@ This creates a structure: `/api/{plugin_id}/categories/posts/*`
 ```ts title="plugins/blog/src/config.api.ts"
 import { buildApiPlugin } from "@vitnode/core/api/lib/plugin";
 
-import { CONFIG_PLUGIN } from "@/config";
 
 import { categoriesModule } from "./api/modules/categories/categories.module"; // [!code ++]
 
 export const blogApiPlugin = () => {
   return buildApiPlugin({
-    pluginId: CONFIG_PLUGIN.pluginId,
-    modules: [categoriesModule] // [!code ++]
+      modules: [categoriesModule] // [!code ++]
   });
 };
 ```

--- a/apps/docs/content/docs/dev/api/routes.mdx
+++ b/apps/docs/content/docs/dev/api/routes.mdx
@@ -11,10 +11,8 @@ Now for the fun part - creating actual endpoints! Each route is a small but migh
 import { z } from "@hono/zod-openapi";
 import { buildRoute } from "@vitnode/core/api/lib/route";
 
-import { CONFIG_PLUGIN } from "@/config";
 
 export const getCategoriesRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "get",
     path: "/",
@@ -54,11 +52,9 @@ export const getCategoriesRoute = buildRoute({
 ```ts title="plugins/blog/src/api/modules/categories/categories.module.ts"
 import { buildModule } from "@vitnode/core/api/lib/module";
 
-import { CONFIG_PLUGIN } from "@/config";
 import { getCategoriesRoute } from "./routes/get.route"; // [!code ++]
 
 export const categoriesModule = buildModule({
-  pluginId: CONFIG_PLUGIN.id,
   name: "categories",
   routes: [getCategoriesRoute] // [!code ++]
 });
@@ -75,10 +71,8 @@ import { z } from "@hono/zod-openapi";
 import { buildRoute } from "@vitnode/core/api/lib/route";
 import { HTTPException } from "hono/http-exception";
 
-import { CONFIG_PLUGIN } from "@/config";
 
 export const getCategoryByIdRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "get",
     // [!code highlight]
@@ -136,10 +130,8 @@ Query parameters are your best friends for filtering, searching, and pagination.
 import { z } from "@hono/zod-openapi";
 import { buildRoute } from "@vitnode/core/api/lib/route";
 
-import { CONFIG_PLUGIN } from "@/config";
 
 export const searchCategoriesRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "get",
     path: "/search",
@@ -203,7 +195,6 @@ When you need to send complex data (creating, updating), request bodies are your
 import { z } from "@hono/zod-openapi";
 import { buildRoute } from "@vitnode/core/api/lib/route";
 
-import { CONFIG_PLUGIN } from "@/config";
 
 const createCategorySchema = z.object({
   name: z.string().min(1).max(100).openapi({
@@ -225,7 +216,6 @@ const createCategorySchema = z.object({
 });
 
 export const createCategoryRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "post",
     path: "/",

--- a/apps/docs/content/docs/dev/captcha/custom-adapter.mdx
+++ b/apps/docs/content/docs/dev/captcha/custom-adapter.mdx
@@ -16,7 +16,6 @@ If you want to use captcha in your custom form or somewhere else, follow these s
 import { buildRoute } from "@vitnode/core/api/lib/route";
 
 export const exampleRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "post",
     description: "Create a new user",

--- a/apps/docs/content/docs/dev/captcha/index.mdx
+++ b/apps/docs/content/docs/dev/captcha/index.mdx
@@ -43,7 +43,6 @@ Add `withCaptcha` to your route config to enable captcha validation for this rou
 import { buildRoute } from "@vitnode/core/api/lib/route";
 
 export const exampleRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "post",
     description: "Create a new user",

--- a/apps/docs/content/docs/dev/cron/index.mdx
+++ b/apps/docs/content/docs/dev/cron/index.mdx
@@ -46,13 +46,11 @@ export const cleanCron = buildCron({
 
 ```ts title="modules/clean/clean.module.ts"
 import { buildModule } from "@vitnode/core/api/lib/module";
-import { CONFIG_PLUGIN } from "@/config";
 
 // [!code ++]
 import { cleanCron } from "./cron/clean.cron";
 
 export const cronModule = buildModule({
-  pluginId: CONFIG_PLUGIN.pluginId,
   name: "clean",
   routes: [],
   // [!code ++]

--- a/apps/docs/content/docs/dev/database/index.mdx
+++ b/apps/docs/content/docs/dev/database/index.mdx
@@ -27,7 +27,6 @@ Access the database in your plugin handlers using `c.get('database')` from the H
 
 ```ts title="plugins/{plugin_name}/src/routes/posts.ts"
 export const postsRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {},
   handler: async (c) => {
     // [!code ++:7]

--- a/apps/docs/content/docs/dev/database/pagination.mdx
+++ b/apps/docs/content/docs/dev/database/pagination.mdx
@@ -19,11 +19,9 @@ import {
   zodPaginationPageInfo,
   zodPaginationQuery
 } from "@/api/lib/with-pagination";
-import { CONFIG_PLUGIN } from "@/config";
 import { core_cron } from "@/database/cron";
 
 export const getCronsRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "get",
     description: "Get Admin Cron Logs",

--- a/packages/vitnode/src/api/lib/module.ts
+++ b/packages/vitnode/src/api/lib/module.ts
@@ -3,41 +3,34 @@ import { OpenAPIHono } from "@hono/zod-openapi";
 import type { BuildCronReturn } from "./cron";
 import type { Route } from "./route";
 
-export interface BuildModuleType<T extends Route, Plugin extends string> {
-  plugin: Plugin;
-  routes: T;
-}
+import { getCurrentPluginId } from "./plugin-context";
 
 export interface BaseBuildModuleReturn<
-  P extends string = string,
   M extends string = string,
-  Routes extends Route<P>[] = Route<P>[],
+  Routes extends Route[] = Route[],
 > {
   cronJobs: BuildCronReturn[];
   hono: OpenAPIHono;
-  modules?: BaseBuildModuleReturn<P>[];
+  modules?: BaseBuildModuleReturn[];
   name: M;
-  pluginId: P;
+  pluginId: string;
   routes: Routes;
 }
 
 export interface BuildModuleReturn<
-  P extends string,
   M extends string,
-  Routes extends Route<P>[] = Route<P>[],
-  Modules extends BaseBuildModuleReturn<P>[] = BaseBuildModuleReturn<P>[],
-> extends BaseBuildModuleReturn<P, M, Routes> {
+  Routes extends Route[] = Route[],
+  Modules extends BaseBuildModuleReturn[] = BaseBuildModuleReturn[],
+> extends BaseBuildModuleReturn<M, Routes> {
   modules?: Modules;
 }
 
 export function buildModule<
-  const P extends string,
   const M extends string,
-  const Routes extends Route<P>[],
-  Modules extends BaseBuildModuleReturn<P>[],
+  const Routes extends Route[],
+  Modules extends BaseBuildModuleReturn[],
 >({
   routes,
-  pluginId,
   name,
   modules,
   cronJobs = [],
@@ -45,9 +38,10 @@ export function buildModule<
   cronJobs?: BuildCronReturn[];
   modules?: Modules;
   name: M;
-  pluginId: P;
   routes: Routes;
-}): BuildModuleReturn<P, M, Routes, Modules> {
+}): BuildModuleReturn<M, Routes, Modules> {
+  const pluginId = getCurrentPluginId();
+
   const hono = new OpenAPIHono();
 
   if (routes) {

--- a/packages/vitnode/src/api/lib/plugin-context.ts
+++ b/packages/vitnode/src/api/lib/plugin-context.ts
@@ -1,0 +1,15 @@
+let currentPluginId: string | undefined;
+
+export const setCurrentPluginId = (pluginId: string) => {
+  currentPluginId = pluginId;
+};
+
+export const getCurrentPluginId = () => {
+  if (!currentPluginId) {
+    throw new Error(
+      "Plugin ID is not defined. Ensure that your plugin config sets it before building modules or routes.",
+    );
+  }
+
+  return currentPluginId;
+};

--- a/packages/vitnode/src/api/lib/plugin.ts
+++ b/packages/vitnode/src/api/lib/plugin.ts
@@ -15,7 +15,7 @@ export function buildApiPlugin<P extends string>({
   pluginId,
   modules = [],
 }: {
-  modules?: BuildModuleReturn<P, string>[];
+  modules?: BuildModuleReturn<string>[];
   pluginId: P;
 }): BuildPluginApiReturn {
   // Run for checking if the plugin is valid

--- a/packages/vitnode/src/api/lib/route.ts
+++ b/packages/vitnode/src/api/lib/route.ts
@@ -7,9 +7,9 @@ import {
   type EnvVitNode,
   pluginMiddleware,
 } from "../middlewares/global.middleware";
+import { getCurrentPluginId } from "./plugin-context";
 
 export const buildRoute = <
-  Plugin extends string,
   P extends string,
   R extends Omit<RouteConfig, "path"> & {
     path: P;
@@ -18,12 +18,11 @@ export const buildRoute = <
 >({
   route,
   handler,
-  pluginId,
 }: {
   handler: RouteHandler<R & { path: P }, EnvVitNode>;
-  pluginId: Plugin;
   route: R;
-}): Route<Plugin, R & { path: P }> => {
+}): Route<R & { path: P }> => {
+  const pluginId = getCurrentPluginId();
   const pluginTag = pluginId
     .split(/[-_]/)
     .map(word => word.charAt(0).toUpperCase() + word.slice(1))
@@ -45,16 +44,13 @@ export const buildRoute = <
       ],
       ...route,
     }) as R & { path: P },
-    handler: handler as Route<Plugin, R & { path: P }>["handler"],
+    handler: handler as Route<R & { path: P }>["handler"],
     pluginId,
   };
 };
 
-export interface Route<
-  Plugin extends string = string,
-  R extends RouteConfig = RouteConfig,
-> {
+export interface Route<R extends RouteConfig = RouteConfig> {
   handler: (...args: unknown[]) => Promise<Response> | Response;
-  pluginId: Plugin;
+  pluginId: string;
   route: R;
 }

--- a/packages/vitnode/src/api/modules/admin/admin.module.ts
+++ b/packages/vitnode/src/api/modules/admin/admin.module.ts
@@ -1,5 +1,4 @@
 import { buildModule } from "@/api/lib/module";
-import { CONFIG_PLUGIN } from "@/config";
 
 import { advancedAdminModule } from "./advanced/advanced.admin.module";
 import { debugAdminModule } from "./debug/debug.admin.module";
@@ -7,7 +6,6 @@ import { sessionAdminRoute } from "./routes/session.route";
 import { usersAdminModule } from "./users/users.admin.module";
 
 export const adminModule = buildModule({
-  pluginId: CONFIG_PLUGIN.pluginId,
   name: "admin",
   routes: [sessionAdminRoute],
   modules: [usersAdminModule, debugAdminModule, advancedAdminModule],

--- a/packages/vitnode/src/api/modules/admin/advanced/advanced.admin.module.ts
+++ b/packages/vitnode/src/api/modules/admin/advanced/advanced.admin.module.ts
@@ -1,10 +1,8 @@
 import { buildModule } from "@/api/lib/module";
-import { CONFIG_PLUGIN } from "@/config";
 
 import { cronAdminModule } from "./cron/cron.admin.module";
 
 export const advancedAdminModule = buildModule({
-  pluginId: CONFIG_PLUGIN.pluginId,
   name: "advanced",
   routes: [],
   modules: [cronAdminModule],

--- a/packages/vitnode/src/api/modules/admin/advanced/cron/cron.admin.module.ts
+++ b/packages/vitnode/src/api/modules/admin/advanced/cron/cron.admin.module.ts
@@ -1,11 +1,9 @@
 import { buildModule } from "@/api/lib/module";
-import { CONFIG_PLUGIN } from "@/config";
 
 import { getCronsRoute } from "./routes/get.route";
 import { runCronRoute } from "./routes/run.route";
 
 export const cronAdminModule = buildModule({
-  pluginId: CONFIG_PLUGIN.pluginId,
   name: "cron",
   routes: [getCronsRoute, runCronRoute],
 });

--- a/packages/vitnode/src/api/modules/admin/advanced/cron/routes/get.route.ts
+++ b/packages/vitnode/src/api/modules/admin/advanced/cron/routes/get.route.ts
@@ -6,11 +6,9 @@ import {
   zodPaginationPageInfo,
   zodPaginationQuery,
 } from "@/api/lib/with-pagination";
-import { CONFIG_PLUGIN } from "@/config";
 import { core_cron } from "@/database/cron";
 
 export const getCronsRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "get",
     description: "Get Admin Cron Logs",

--- a/packages/vitnode/src/api/modules/admin/advanced/cron/routes/run.route.ts
+++ b/packages/vitnode/src/api/modules/admin/advanced/cron/routes/run.route.ts
@@ -4,12 +4,10 @@ import { z } from "zod";
 import type { CronJobConfig } from "@/api/lib/cron";
 
 import { buildRoute } from "@/api/lib/route";
-import { CONFIG_PLUGIN } from "@/config";
 import { core_cron } from "@/database/cron";
 import { getNextCronRunDate } from "@/lib/api/get-next-cron-run-date";
 
 export const runCronRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "post",
     description: "Run a specific cron job",

--- a/packages/vitnode/src/api/modules/admin/debug/debug.admin.module.ts
+++ b/packages/vitnode/src/api/modules/admin/debug/debug.admin.module.ts
@@ -1,9 +1,7 @@
-import { CONFIG_PLUGIN } from "../../../../config";
 import { buildModule } from "../../../lib/module";
 import { logsDebugAdminRoute } from "./routes/logs.route";
 
 export const debugAdminModule = buildModule({
-  pluginId: CONFIG_PLUGIN.pluginId,
   name: "debug",
   routes: [logsDebugAdminRoute],
 });

--- a/packages/vitnode/src/api/modules/admin/debug/routes/logs.route.ts
+++ b/packages/vitnode/src/api/modules/admin/debug/routes/logs.route.ts
@@ -1,7 +1,6 @@
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
-import { CONFIG_PLUGIN } from "@/config";
 import { core_logs } from "@/database/logs";
 
 import { core_users } from "../../../../../database/users";
@@ -13,7 +12,6 @@ import {
 } from "../../../../lib/with-pagination";
 
 export const logsDebugAdminRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "get",
     description: "Get Admin Debug Logs",

--- a/packages/vitnode/src/api/modules/admin/routes/session.route.ts
+++ b/packages/vitnode/src/api/modules/admin/routes/session.route.ts
@@ -5,7 +5,6 @@ import { buildRoute } from "@/api/lib/route";
 import { CONFIG_PLUGIN } from "@/config";
 
 export const sessionAdminRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "get",
     description: "Verify admin session",

--- a/packages/vitnode/src/api/modules/admin/users/routes/list.route.ts
+++ b/packages/vitnode/src/api/modules/admin/users/routes/list.route.ts
@@ -6,11 +6,9 @@ import {
   zodPaginationPageInfo,
   zodPaginationQuery,
 } from "@/api/lib/with-pagination";
-import { CONFIG_PLUGIN } from "@/config";
 import { core_users } from "@/database/users";
 
 export const listUsersAdminRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "get",
     description: "Get list of all users",

--- a/packages/vitnode/src/api/modules/admin/users/routes/users.route.ts
+++ b/packages/vitnode/src/api/modules/admin/users/routes/users.route.ts
@@ -6,11 +6,9 @@ import {
   zodPaginationPageInfo,
   zodPaginationQuery,
 } from "@/api/lib/with-pagination";
-import { CONFIG_PLUGIN } from "@/config";
 import { core_users } from "@/database/users";
 
 export const usersAdminRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "get",
     description: "Get list of all users (Admin only)",

--- a/packages/vitnode/src/api/modules/admin/users/users.admin.module.ts
+++ b/packages/vitnode/src/api/modules/admin/users/users.admin.module.ts
@@ -1,10 +1,8 @@
 import { buildModule } from "@/api/lib/module";
-import { CONFIG_PLUGIN } from "@/config";
 
 import { listUsersAdminRoute } from "./routes/list.route";
 
 export const usersAdminModule = buildModule({
-  pluginId: CONFIG_PLUGIN.pluginId,
   name: "users",
   routes: [listUsersAdminRoute],
 });

--- a/packages/vitnode/src/api/modules/cron/cron.module.ts
+++ b/packages/vitnode/src/api/modules/cron/cron.module.ts
@@ -1,11 +1,9 @@
 import { buildModule } from "@/api/lib/module";
-import { CONFIG_PLUGIN } from "@/config";
 
 import { cleanCron } from "./cron/clean.cron";
 import { runCronRoute } from "./routes/cron.route";
 
 export const cronModule = buildModule({
-  pluginId: CONFIG_PLUGIN.pluginId,
   name: "cron",
   routes: [runCronRoute],
   cronJobs: [cleanCron],

--- a/packages/vitnode/src/api/modules/cron/routes/cron.route.ts
+++ b/packages/vitnode/src/api/modules/cron/routes/cron.route.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 
 import { buildRoute } from "@/api/lib/route";
 import { cronAuthMiddleware } from "@/api/middlewares/cron-auth.middleware";
-import { CONFIG_PLUGIN } from "@/config";
 import { core_cron } from "@/database/cron";
 import { getNextCronRunDate } from "@/lib/api/get-next-cron-run-date";
 
@@ -14,7 +13,6 @@ import {
 } from "../helpers/process-cron-jobs";
 
 export const runCronRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "post",
     description: "Run cron job",

--- a/packages/vitnode/src/api/modules/middleware/middleware.module.ts
+++ b/packages/vitnode/src/api/modules/middleware/middleware.module.ts
@@ -1,10 +1,8 @@
 import { buildModule } from "@/api/lib/module";
-import { CONFIG_PLUGIN } from "@/config";
 
 import { routeMiddleware } from "./route";
 
 export const middlewareModule = buildModule({
-  pluginId: CONFIG_PLUGIN.pluginId,
   name: "middleware",
   routes: [routeMiddleware],
 });

--- a/packages/vitnode/src/api/modules/middleware/route.ts
+++ b/packages/vitnode/src/api/modules/middleware/route.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 
 import { buildRoute } from "@/api/lib/route";
-import { CONFIG_PLUGIN } from "@/config";
 
 export const routeMiddlewareSchema = z.object({
   sso: z.array(z.object({ id: z.string(), name: z.string() })),
@@ -15,7 +14,6 @@ export const routeMiddlewareSchema = z.object({
 });
 
 export const routeMiddleware = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     path: "/",
     method: "get",

--- a/packages/vitnode/src/api/modules/users/routes/change-password.route.ts
+++ b/packages/vitnode/src/api/modules/users/routes/change-password.route.ts
@@ -4,7 +4,6 @@ import { z } from "zod";
 
 import { buildRoute } from "@/api/lib/route";
 import { PasswordModel } from "@/api/models/password";
-import { CONFIG_PLUGIN } from "@/config";
 import { core_users, core_users_forgot_password } from "@/database/users";
 
 export const zodChangePasswordSchema = z.object({
@@ -16,7 +15,6 @@ export const zodChangePasswordSchema = z.object({
 });
 
 export const changePasswordRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "post",
     description: "Change user password",

--- a/packages/vitnode/src/api/modules/users/routes/reset-passowrd.route.ts
+++ b/packages/vitnode/src/api/modules/users/routes/reset-passowrd.route.ts
@@ -4,13 +4,11 @@ import { z } from "zod";
 
 import { buildRoute } from "@/api/lib/route";
 import { ForgotPasswordTokenModel } from "@/api/models/password";
-import { CONFIG_PLUGIN } from "@/config";
 import { core_users, core_users_forgot_password } from "@/database/users";
 import ResetPasswordEmailTemplate from "@/emails/reset-password";
 import { CONFIG } from "@/lib/config";
 
 export const resetPasswordRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "post",
     description: "Request a password reset",

--- a/packages/vitnode/src/api/modules/users/routes/session.route.ts
+++ b/packages/vitnode/src/api/modules/users/routes/session.route.ts
@@ -2,10 +2,8 @@ import { z } from "zod";
 
 import { buildRoute } from "@/api/lib/route";
 import { SessionAdminModel } from "@/api/models/session-admin";
-import { CONFIG_PLUGIN } from "@/config";
 
 export const sessionRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "get",
     description: "Verify session",

--- a/packages/vitnode/src/api/modules/users/routes/sign-in.route.ts
+++ b/packages/vitnode/src/api/modules/users/routes/sign-in.route.ts
@@ -4,7 +4,6 @@ import { buildRoute } from "@/api/lib/route";
 import { SessionModel } from "@/api/models/session";
 import { SessionAdminModel } from "@/api/models/session-admin";
 import { UserModel } from "@/api/models/user";
-import { CONFIG_PLUGIN } from "@/config";
 
 export const zodSignInSchema = z.object({
   email: z.email().toLowerCase().openapi({
@@ -19,7 +18,6 @@ export const zodSignInSchema = z.object({
 });
 
 export const signInRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "post",
     description: "Sign in with email and password",

--- a/packages/vitnode/src/api/modules/users/routes/sign-out.route.ts
+++ b/packages/vitnode/src/api/modules/users/routes/sign-out.route.ts
@@ -3,10 +3,8 @@ import { z } from "@hono/zod-openapi";
 import { buildRoute } from "@/api/lib/route";
 import { SessionModel } from "@/api/models/session";
 import { SessionAdminModel } from "@/api/models/session-admin";
-import { CONFIG_PLUGIN } from "@/config";
 
 export const signOutRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "delete",
     description: "Sign out the current admin",

--- a/packages/vitnode/src/api/modules/users/routes/sign-up.route.ts
+++ b/packages/vitnode/src/api/modules/users/routes/sign-up.route.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 import { buildRoute } from "@/api/lib/route";
 import { PasswordModel } from "@/api/models/password";
 import { UserModel } from "@/api/models/user";
-import { CONFIG_PLUGIN } from "@/config";
 
 import { SessionModel } from "../../../models/session";
 
@@ -27,7 +26,6 @@ export const zodSignUpSchema = z.object({
 });
 
 export const signUpRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "post",
     description: "Create a new user",

--- a/packages/vitnode/src/api/modules/users/routes/test.route.ts
+++ b/packages/vitnode/src/api/modules/users/routes/test.route.ts
@@ -1,10 +1,8 @@
 import { z } from "zod";
 
 import { buildRoute } from "@/api/lib/route";
-import { CONFIG_PLUGIN } from "@/config";
 
 export const testRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "post",
     description: "Test route",

--- a/packages/vitnode/src/api/modules/users/sso/routes/callback.route.ts
+++ b/packages/vitnode/src/api/modules/users/sso/routes/callback.route.ts
@@ -3,10 +3,8 @@ import { z } from "zod";
 import { buildRoute } from "@/api/lib/route";
 import { SessionModel } from "@/api/models/session";
 import { SSOModel } from "@/api/models/sso";
-import { CONFIG_PLUGIN } from "@/config";
 
 export const callbackRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "get",
     description: "SSO Callback",

--- a/packages/vitnode/src/api/modules/users/sso/routes/create-url.route.ts
+++ b/packages/vitnode/src/api/modules/users/sso/routes/create-url.route.ts
@@ -2,10 +2,8 @@ import { z } from "zod";
 
 import { buildRoute } from "@/api/lib/route";
 import { SSOModel } from "@/api/models/sso";
-import { CONFIG_PLUGIN } from "@/config";
 
 export const createUrlRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "post",
     description: "Generate SSO URL",

--- a/packages/vitnode/src/api/modules/users/sso/sso.module.ts
+++ b/packages/vitnode/src/api/modules/users/sso/sso.module.ts
@@ -1,11 +1,9 @@
 import { buildModule } from "@/api/lib/module";
-import { CONFIG_PLUGIN } from "@/config";
 
 import { callbackRoute } from "./routes/callback.route";
 import { createUrlRoute } from "./routes/create-url.route";
 
 export const ssoUserModule = buildModule({
-  pluginId: CONFIG_PLUGIN.pluginId,
   name: "sso",
   routes: [callbackRoute, createUrlRoute],
 });

--- a/packages/vitnode/src/api/modules/users/users.module.ts
+++ b/packages/vitnode/src/api/modules/users/users.module.ts
@@ -1,5 +1,4 @@
 import { buildModule } from "@/api/lib/module";
-import { CONFIG_PLUGIN } from "@/config";
 
 import { changePasswordRoute } from "./routes/change-password.route";
 import { resetPasswordRoute } from "./routes/reset-passowrd.route";
@@ -11,7 +10,6 @@ import { testRoute } from "./routes/test.route";
 import { ssoUserModule } from "./sso/sso.module";
 
 export const usersModule = buildModule({
-  pluginId: CONFIG_PLUGIN.pluginId,
   name: "users",
   routes: [
     sessionRoute,

--- a/packages/vitnode/src/config.ts
+++ b/packages/vitnode/src/config.ts
@@ -1,4 +1,8 @@
+import { setCurrentPluginId } from "@/api/lib/plugin-context";
+
 export const CONFIG_PLUGIN = {
   pluginId: "@vitnode/core" as const,
   version: "2.0.0-canary.0",
 };
+
+setCurrentPluginId(CONFIG_PLUGIN.pluginId);

--- a/plugins/blog/src/api/modules/admin/admin.module.ts
+++ b/plugins/blog/src/api/modules/admin/admin.module.ts
@@ -1,11 +1,9 @@
 import { buildModule } from "@vitnode/core/api/lib/module";
 
-import { CONFIG_PLUGIN } from "../../../const";
 import { categoriesAdminModule } from "./categories/categories.admin.module";
 import { postsAdminModule } from "./posts/posts.admin.module";
 
 export const adminModule = buildModule({
-  pluginId: CONFIG_PLUGIN.pluginId,
   name: "admin",
   modules: [categoriesAdminModule, postsAdminModule],
   routes: [],

--- a/plugins/blog/src/api/modules/admin/categories/categories.admin.module.ts
+++ b/plugins/blog/src/api/modules/admin/categories/categories.admin.module.ts
@@ -1,12 +1,10 @@
 import { buildModule } from "@vitnode/core/api/lib/module";
 
-import { CONFIG_PLUGIN } from "../../../../const";
 import { createCategoryRoute } from "./routes/create.route";
 import { deleteCategoryRoute } from "./routes/delete.route";
 import { editCategoryRoute } from "./routes/edit.route";
 
 export const categoriesAdminModule = buildModule({
-  pluginId: CONFIG_PLUGIN.pluginId,
   name: "categories",
   routes: [createCategoryRoute, editCategoryRoute, deleteCategoryRoute],
 });

--- a/plugins/blog/src/api/modules/admin/categories/routes/create.route.ts
+++ b/plugins/blog/src/api/modules/admin/categories/routes/create.route.ts
@@ -4,7 +4,6 @@ import { removeSpecialCharacters } from "@vitnode/core/lib/special-characters";
 import { eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 
-import { CONFIG_PLUGIN } from "@/const";
 import { blog_categories } from "@/database/categories";
 
 const zodCategoryResponseSchema = z.object({
@@ -19,7 +18,6 @@ export const zodCreateCategorySchema = z.object({
 });
 
 export const createCategoryRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "post",
     path: "/",

--- a/plugins/blog/src/api/modules/admin/categories/routes/delete.route.ts
+++ b/plugins/blog/src/api/modules/admin/categories/routes/delete.route.ts
@@ -3,11 +3,9 @@ import { buildRoute } from "@vitnode/core/api/lib/route";
 import { eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 
-import { CONFIG_PLUGIN } from "@/const";
 import { blog_categories } from "@/database/categories";
 
 export const deleteCategoryRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "delete",
     path: "/{id}",

--- a/plugins/blog/src/api/modules/admin/categories/routes/edit.route.ts
+++ b/plugins/blog/src/api/modules/admin/categories/routes/edit.route.ts
@@ -4,7 +4,6 @@ import { removeSpecialCharacters } from "@vitnode/core/lib/special-characters";
 import { eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 
-import { CONFIG_PLUGIN } from "@/const";
 import { blog_categories } from "@/database/categories";
 
 import { zodCreateCategorySchema } from "./create.route";
@@ -17,7 +16,6 @@ const zodCategoryResponseSchema = z.object({
 });
 
 export const editCategoryRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "put",
     path: "/{id}",

--- a/plugins/blog/src/api/modules/admin/posts/posts.admin.module.ts
+++ b/plugins/blog/src/api/modules/admin/posts/posts.admin.module.ts
@@ -1,12 +1,10 @@
 import { buildModule } from "@vitnode/core/api/lib/module";
 
-import { CONFIG_PLUGIN } from "../../../../const";
 import { createPostRoute } from "./routes/create.route";
 import { deletePostRoute } from "./routes/delete.route";
 import { editPostRoute } from "./routes/edit.route";
 
 export const postsAdminModule = buildModule({
-  pluginId: CONFIG_PLUGIN.pluginId,
   name: "posts",
   routes: [editPostRoute, createPostRoute, deletePostRoute],
 });

--- a/plugins/blog/src/api/modules/admin/posts/routes/create.route.ts
+++ b/plugins/blog/src/api/modules/admin/posts/routes/create.route.ts
@@ -4,7 +4,6 @@ import { removeSpecialCharacters } from "@vitnode/core/lib/special-characters";
 import { eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 
-import { CONFIG_PLUGIN } from "@/const";
 import { blog_categories } from "@/database/categories";
 import { blog_posts } from "@/database/posts";
 
@@ -28,7 +27,6 @@ export const zodCreatePostSchema = z.object({
 });
 
 export const createPostRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "post",
     path: "/",

--- a/plugins/blog/src/api/modules/admin/posts/routes/delete.route.ts
+++ b/plugins/blog/src/api/modules/admin/posts/routes/delete.route.ts
@@ -3,11 +3,9 @@ import { buildRoute } from "@vitnode/core/api/lib/route";
 import { eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 
-import { CONFIG_PLUGIN } from "@/const";
 import { blog_posts } from "@/database/posts";
 
 export const deletePostRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "delete",
     path: "/{id}",

--- a/plugins/blog/src/api/modules/admin/posts/routes/edit.route.ts
+++ b/plugins/blog/src/api/modules/admin/posts/routes/edit.route.ts
@@ -4,7 +4,6 @@ import { removeSpecialCharacters } from "@vitnode/core/lib/special-characters";
 import { eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 
-import { CONFIG_PLUGIN } from "@/const";
 import { blog_categories } from "@/database/categories";
 import { blog_posts } from "@/database/posts";
 
@@ -21,7 +20,6 @@ const zodPostResponseSchema = z.object({
 });
 
 export const editPostRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "put",
     path: "/{id}",

--- a/plugins/blog/src/api/modules/categories/categories.module.ts
+++ b/plugins/blog/src/api/modules/categories/categories.module.ts
@@ -1,12 +1,10 @@
 import { buildModule } from "@vitnode/core/api/lib/module";
 
-import { CONFIG_PLUGIN } from "@/const";
 
 import { categoriesRoute } from "./routes/get.route";
 import { testRoute } from "./test.route";
 
 export const categoriesModule = buildModule({
-  pluginId: CONFIG_PLUGIN.pluginId,
   name: "categories",
   routes: [categoriesRoute, testRoute],
 });

--- a/plugins/blog/src/api/modules/categories/routes/get.route.ts
+++ b/plugins/blog/src/api/modules/categories/routes/get.route.ts
@@ -7,7 +7,6 @@ import {
 } from "@vitnode/core/api/lib/with-pagination";
 import { and, ilike, type SQL } from "drizzle-orm";
 
-import { CONFIG_PLUGIN } from "@/const";
 import { blog_categories } from "@/database/categories";
 
 const zodCategorySchema = z.object({
@@ -18,7 +17,6 @@ const zodCategorySchema = z.object({
 });
 
 export const categoriesRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "get",
     path: "/",

--- a/plugins/blog/src/api/modules/categories/test.route.ts
+++ b/plugins/blog/src/api/modules/categories/test.route.ts
@@ -2,11 +2,9 @@ import { buildRoute } from "@vitnode/core/api/lib/route";
 import { UserModel } from "@vitnode/core/api/models/user";
 import { z } from "zod";
 
-import { CONFIG_PLUGIN } from "@/const";
 import TestTemplateEmail from "@/emails/test-template";
 
 export const testRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "post",
     description: "Test route",

--- a/plugins/blog/src/api/modules/posts/posts.module.ts
+++ b/plugins/blog/src/api/modules/posts/posts.module.ts
@@ -1,11 +1,9 @@
 import { buildModule } from "@vitnode/core/api/lib/module";
 
-import { CONFIG_PLUGIN } from "@/const";
 
 import { postsRoute } from "./routes/get.route";
 
 export const postsModule = buildModule({
-  pluginId: CONFIG_PLUGIN.pluginId,
   name: "posts",
   routes: [postsRoute],
 });

--- a/plugins/blog/src/api/modules/posts/routes/get.route.ts
+++ b/plugins/blog/src/api/modules/posts/routes/get.route.ts
@@ -7,7 +7,6 @@ import {
 } from "@vitnode/core/api/lib/with-pagination";
 import { eq } from "drizzle-orm";
 
-import { CONFIG_PLUGIN } from "@/const";
 import { blog_categories } from "@/database/categories";
 import { blog_posts } from "@/database/posts";
 
@@ -27,7 +26,6 @@ export const zodPostSchema = z.object({
 });
 
 export const postsRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "get",
     path: "/",

--- a/plugins/blog/src/const.ts
+++ b/plugins/blog/src/const.ts
@@ -1,3 +1,7 @@
+import { setCurrentPluginId } from "@vitnode/core/api/lib/plugin-context";
+
 export const CONFIG_PLUGIN = {
   pluginId: "@vitnode/blog" as const,
 };
+
+setCurrentPluginId(CONFIG_PLUGIN.pluginId);


### PR DESCRIPTION
## Summary
- add a shared plugin context that stores the current plugin ID and register it from each plugin's config
- update the module and route builders, core modules, blog plugin modules, and the docs so they infer the plugin ID from the shared context instead of receiving it explicitly

## Testing
- `pnpm --filter @vitnode/core test`
- `pnpm --filter @vitnode/core lint` *(fails: existing @typescript-eslint/no-unsafe-argument violations in views)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69199bd40aac8324acf5f4bb74e8af44)