### PR TITLE
Fix lint issues after pluginId removal

### DIFF
--- a/apps/docs/content/docs/dev/api/modules.mdx
+++ b/apps/docs/content/docs/dev/api/modules.mdx
@@ -13,10 +13,11 @@ import { buildModule } from "@vitnode/core/api/lib/module";
 import { CONFIG_PLUGIN } from "@/config";
 
 export const categoriesModule = buildModule({
-  pluginId: CONFIG_PLUGIN.id,
   name: "categories",
   routes: [] // We'll populate this soon!
 });
+
+export const categoriesModuleApi = categoriesModule.build(CONFIG_PLUGIN.pluginId);
 ```
 
 #### Nested Modules
@@ -31,11 +32,12 @@ import { CONFIG_PLUGIN } from "@/config";
 import { postsModule } from "./posts/posts.module"; // [!code ++]
 
 export const categoriesModule = buildModule({
-  pluginId: CONFIG_PLUGIN.id,
   name: "categories",
   routes: [],
   modules: [postsModule] // [!code ++]
 });
+
+export const categoriesModuleApi = categoriesModule.build(CONFIG_PLUGIN.pluginId);
 ```
 
 This creates a structure: `/api/{plugin_id}/categories/posts/*`

--- a/apps/docs/content/docs/dev/api/routes.mdx
+++ b/apps/docs/content/docs/dev/api/routes.mdx
@@ -11,10 +11,7 @@ Now for the fun part - creating actual endpoints! Each route is a small but migh
 import { z } from "@hono/zod-openapi";
 import { buildRoute } from "@vitnode/core/api/lib/route";
 
-import { CONFIG_PLUGIN } from "@/config";
-
 export const getCategoriesRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "get",
     path: "/",
@@ -58,10 +55,11 @@ import { CONFIG_PLUGIN } from "@/config";
 import { getCategoriesRoute } from "./routes/get.route"; // [!code ++]
 
 export const categoriesModule = buildModule({
-  pluginId: CONFIG_PLUGIN.id,
   name: "categories",
   routes: [getCategoriesRoute] // [!code ++]
 });
+
+export const categoriesModuleApi = categoriesModule.build(CONFIG_PLUGIN.pluginId);
 ```
 
 ## Inputs
@@ -75,10 +73,7 @@ import { z } from "@hono/zod-openapi";
 import { buildRoute } from "@vitnode/core/api/lib/route";
 import { HTTPException } from "hono/http-exception";
 
-import { CONFIG_PLUGIN } from "@/config";
-
 export const getCategoryByIdRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "get",
     // [!code highlight]
@@ -136,10 +131,7 @@ Query parameters are your best friends for filtering, searching, and pagination.
 import { z } from "@hono/zod-openapi";
 import { buildRoute } from "@vitnode/core/api/lib/route";
 
-import { CONFIG_PLUGIN } from "@/config";
-
 export const searchCategoriesRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "get",
     path: "/search",

--- a/apps/docs/content/docs/dev/captcha/custom-adapter.mdx
+++ b/apps/docs/content/docs/dev/captcha/custom-adapter.mdx
@@ -16,7 +16,6 @@ If you want to use captcha in your custom form or somewhere else, follow these s
 import { buildRoute } from "@vitnode/core/api/lib/route";
 
 export const exampleRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "post",
     description: "Create a new user",
@@ -96,6 +95,7 @@ export const FormSignUp = ({
 import type { z } from "zod";
 
 import { fetcher } from "@vitnode/core/lib/fetcher";
+import { usersModuleApi } from "@vitnode/core/api/modules/users/users.module";
 
 export const mutationApi = async ({
   captchaToken, // [!code ++]
@@ -103,7 +103,7 @@ export const mutationApi = async ({
   // [!code ++]
   captchaToken;
 }) => {
-  await fetcher(usersModule, {
+  await fetcher(usersModuleApi, {
     path: "/test",
     method: "post",
     module: "blog",

--- a/apps/docs/content/docs/dev/captcha/index.mdx
+++ b/apps/docs/content/docs/dev/captcha/index.mdx
@@ -157,13 +157,14 @@ Next, you need to set `captchaToken` in your mutation API call. This token is pr
 import type { z } from "zod";
 
 import { fetcher } from "@vitnode/core/lib/fetcher";
+import { usersModuleApi } from "@vitnode/core/api/modules/users/users.module";
 
 export const mutationApi = async ({
   captchaToken, // [!code ++]
   ...input
 }: // [!code ++]
 z.infer<typeof zodSignUpSchema> & { captchaToken: string }) => {
-  const res = await fetcher(usersModule, {
+  const res = await fetcher(usersModuleApi, {
     path: "/sign_up",
     method: "post",
     module: "users",

--- a/apps/docs/content/docs/dev/fetcher.mdx
+++ b/apps/docs/content/docs/dev/fetcher.mdx
@@ -16,13 +16,13 @@ First, import the required dependencies:
 
 ```ts
 import { fetcher } from '@vitnode/core/lib/fetcher';
-import { usersModule } from '@vitnode/core/api/modules/users/users.module';
+import { usersModuleApi } from '@vitnode/core/api/modules/users/users.module';
 ```
 
 Make your first API call:
 
 ```ts
-const response = await fetcher(usersModule, {
+const response = await fetcher(usersModuleApi, {
   path: '/session',
   method: 'get',
   module: 'users',
@@ -66,7 +66,7 @@ const response = await fetcher(categoriesAdminModule, {
 You can leverage Next.js caching by passing cache options:
 
 ```ts
-const response = await fetcher(usersModule, {
+const response = await fetcher(usersModuleApi, {
   path: '/session',
   method: 'get',
   module: 'users',
@@ -88,7 +88,7 @@ When working with authentication or sessions, you might need to handle cookies. 
 Here's how to enable cookie handling for a sign-in request:
 
 ```ts
-const response = await fetcher(usersModule, {
+const response = await fetcher(usersModuleApi, {
   path: '/sign_in',
   method: 'post',
   module: 'users',

--- a/apps/docs/src/app/[locale]/(docs)/docs/[[...slug]]/page.tsx
+++ b/apps/docs/src/app/[locale]/(docs)/docs/[[...slug]]/page.tsx
@@ -12,12 +12,16 @@ import { source } from "@/lib/source";
 
 import { ViewOptions } from "./page.client";
 
-export default async function Page(
-  props: PageProps<"/[locale]/docs/[[...slug]]">,
-) {
+interface DocsPageParams {
+  slug?: string[];
+}
+
+export default async function Page(props: { params: Promise<DocsPageParams> }) {
   const params = await props.params;
   if (!params.slug) {
     await redirect("/docs/dev");
+
+    return null;
   }
   const page = source.getPage(params.slug);
   if (!page) notFound();
@@ -58,9 +62,12 @@ export default async function Page(
 // }
 
 export async function generateMetadata(props: {
-  params: Promise<{ slug?: string[] }>;
+  params: Promise<DocsPageParams>;
 }): Promise<Metadata> {
   const params = await props.params;
+  if (!params.slug) {
+    notFound();
+  }
   const page = source.getPage(params.slug);
   if (!page) notFound();
 

--- a/apps/docs/src/components/animated-beam/animated-beam-home.tsx
+++ b/apps/docs/src/components/animated-beam/animated-beam-home.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import type React from "react";
-
 import {
   Tooltip,
   TooltipContent,
@@ -20,32 +18,31 @@ import {
   Sparkle,
   Users,
 } from "lucide-react";
-import { useRef } from "react";
+import { type ComponentProps, type Ref, useRef } from "react";
 
 import { LogoVitNode } from "../logo-vitnode";
 import { AnimatedBeam } from "./animated-beam";
 
-const Circle = ({
-  className,
-  tooltip,
-  ...props
-}: React.ComponentProps<typeof Link> & {
+interface CircleProps extends ComponentProps<typeof Link> {
+  anchorRef?: Ref<HTMLAnchorElement>;
   tooltip?: string;
-}) => {
+}
+
+const Circle = ({ className, tooltip, anchorRef, ...props }: CircleProps) => {
   const classNameLink = cn(
     "bg-card hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-ring/50 z-10 flex size-12 items-center justify-center rounded-md border p-3 transition-all focus-visible:ring-[3px]",
     className,
   );
 
   if (!tooltip) {
-    return <Link className={classNameLink} {...props} />;
+    return <Link className={classNameLink} ref={anchorRef} {...props} />;
   }
 
   return (
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger asChild>
-          <Link className={classNameLink} {...props} />
+          <Link className={classNameLink} ref={anchorRef} {...props} />
         </TooltipTrigger>
 
         <TooltipContent>{tooltip}</TooltipContent>
@@ -75,40 +72,40 @@ export function AnimatedBeamHome() {
     >
       <div className="flex size-full max-w-lg flex-col items-stretch justify-between gap-10">
         <div className="flex flex-row items-center justify-between">
-          <Circle href="/" ref={div1Ref} tooltip="Users">
+          <Circle anchorRef={div1Ref} href="/" tooltip="Users">
             <Users />
           </Circle>
           <Circle
+            anchorRef={div8Ref}
             href="/docs/dev/email/overview"
-            ref={div8Ref}
             tooltip="Emails"
           >
             <AtSign />
           </Circle>
-          <Circle href="/" ref={div5Ref} tooltip="Plugins">
+          <Circle anchorRef={div5Ref} href="/" tooltip="Plugins">
             <Plug />
           </Circle>
         </div>
         <div className="flex flex-row items-center justify-between">
-          <Circle href="/" ref={div2Ref} tooltip="Languages">
+          <Circle anchorRef={div2Ref} href="/" tooltip="Languages">
             <Languages />
           </Circle>
 
-          <Circle className="size-16" href="/docs/dev" ref={div4Ref}>
+          <Circle anchorRef={div4Ref} className="size-16" href="/docs/dev">
             <LogoVitNode small />
           </Circle>
-          <Circle href="/" ref={div6Ref} tooltip="Themes">
+          <Circle anchorRef={div6Ref} href="/" tooltip="Themes">
             <Paintbrush />
           </Circle>
         </div>
         <div className="flex flex-row items-center justify-between">
-          <Circle href="/" ref={div3Ref} tooltip="Authorization">
+          <Circle anchorRef={div3Ref} href="/" tooltip="Authorization">
             <ShieldCheck />
           </Circle>
-          <Circle href="/" ref={div9Ref} tooltip="AI">
+          <Circle anchorRef={div9Ref} href="/" tooltip="AI">
             <Sparkle />
           </Circle>
-          <Circle href="/" ref={div7Ref} tooltip="Database">
+          <Circle anchorRef={div7Ref} href="/" tooltip="Database">
             <Database />
           </Circle>
         </div>

--- a/packages/vitnode/src/api/lib/module.ts
+++ b/packages/vitnode/src/api/lib/module.ts
@@ -1,7 +1,10 @@
-import { OpenAPIHono } from "@hono/zod-openapi";
+import { createRoute as createRouteHono, OpenAPIHono } from "@hono/zod-openapi";
 
 import type { BuildCronReturn } from "./cron";
 import type { Route } from "./route";
+
+import { captchaMiddleware } from "../middlewares/captcha.middleware";
+import { pluginMiddleware } from "../middlewares/global.middleware";
 
 export interface BuildModuleType<T extends Route, Plugin extends string> {
   plugin: Plugin;
@@ -11,7 +14,7 @@ export interface BuildModuleType<T extends Route, Plugin extends string> {
 export interface BaseBuildModuleReturn<
   P extends string = string,
   M extends string = string,
-  Routes extends Route<P>[] = Route<P>[],
+  Routes extends Route[] = Route[],
 > {
   cronJobs: BuildCronReturn[];
   hono: OpenAPIHono;
@@ -24,20 +27,42 @@ export interface BaseBuildModuleReturn<
 export interface BuildModuleReturn<
   P extends string,
   M extends string,
-  Routes extends Route<P>[] = Route<P>[],
-  Modules extends BaseBuildModuleReturn<P>[] = BaseBuildModuleReturn<P>[],
+  Routes extends Route[] = Route[],
+  Modules extends BaseBuildModuleReturn<P>[] | undefined =
+    | BaseBuildModuleReturn<P>[]
+    | undefined,
 > extends BaseBuildModuleReturn<P, M, Routes> {
   modules?: Modules;
 }
 
+type InferBuiltModules<
+  Modules extends BuildModuleDefinition<string>[] | undefined,
+> = Modules extends BuildModuleDefinition<string>[]
+  ? ReturnType<Modules[number]["build"]>[]
+  : [];
+
+export interface BuildModuleDefinition<
+  M extends string,
+  Routes extends Route[] = Route[],
+  Modules extends BuildModuleDefinition<string>[] | undefined =
+    | BuildModuleDefinition<string>[]
+    | undefined,
+> {
+  build: <P extends string>(
+    pluginId: P,
+  ) => BuildModuleReturn<P, M, Routes, InferBuiltModules<Modules>>;
+  cronJobs: BuildCronReturn[];
+  modules?: Modules;
+  name: M;
+  routes: Routes;
+}
+
 export function buildModule<
-  const P extends string,
   const M extends string,
-  const Routes extends Route<P>[],
-  Modules extends BaseBuildModuleReturn<P>[],
+  const Routes extends Route[],
+  Modules extends BuildModuleDefinition<string>[] | undefined,
 >({
   routes,
-  pluginId,
   name,
   modules,
   cronJobs = [],
@@ -45,22 +70,65 @@ export function buildModule<
   cronJobs?: BuildCronReturn[];
   modules?: Modules;
   name: M;
-  pluginId: P;
   routes: Routes;
-}): BuildModuleReturn<P, M, Routes, Modules> {
-  const hono = new OpenAPIHono();
+}): BuildModuleDefinition<M, Routes, Modules> {
+  return {
+    routes,
+    name,
+    modules,
+    cronJobs,
+    build<P extends string>(pluginId: P) {
+      const hono = new OpenAPIHono();
 
-  if (routes) {
-    routes.forEach(({ handler, route }) => {
-      hono.openapi(route, handler);
-    });
-  }
+      if (routes) {
+        routes.forEach(({ handler, route }) => {
+          const pluginTag = pluginId
+            .split(/[-_]/)
+            .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+            .join(" ");
 
-  if (modules) {
-    modules.forEach(module => {
-      hono.route(`/${module.name}`, module.hono);
-    });
-  }
+          const tags = [pluginTag, ...(route.tags ?? [])];
 
-  return { routes, pluginId, hono, name, modules, cronJobs };
+          const middleware = [
+            pluginMiddleware(pluginId),
+            ...(route.withCaptcha ? [captchaMiddleware()] : []),
+            ...(Array.isArray(route.middleware)
+              ? route.middleware
+              : route.middleware
+                ? [route.middleware]
+                : []),
+          ];
+
+          const honoRoute = createRouteHono({
+            ...route,
+            middleware,
+            tags,
+          });
+
+          hono.openapi(honoRoute as Route["route"], handler);
+        });
+      }
+
+      let builtModules = [] as InferBuiltModules<Modules>;
+
+      if (modules) {
+        builtModules = modules.map(module =>
+          module.build(pluginId),
+        ) as InferBuiltModules<Modules>;
+
+        builtModules?.forEach(module => {
+          hono.route(`/${module.name}`, module.hono);
+        });
+      }
+
+      return {
+        routes,
+        pluginId,
+        hono,
+        name,
+        modules: builtModules,
+        cronJobs,
+      } as BuildModuleReturn<P, M, Routes, InferBuiltModules<Modules>>;
+    },
+  };
 }

--- a/packages/vitnode/src/api/lib/plugin.ts
+++ b/packages/vitnode/src/api/lib/plugin.ts
@@ -1,7 +1,7 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
 
 import type { CronJobConfig } from "./cron";
-import type { BuildModuleReturn } from "./module";
+import type { BuildModuleDefinition } from "./module";
 
 import { checkPluginId } from "./check-plugin-id";
 
@@ -15,7 +15,7 @@ export function buildApiPlugin<P extends string>({
   pluginId,
   modules = [],
 }: {
-  modules?: BuildModuleReturn<P, string>[];
+  modules?: BuildModuleDefinition<string>[];
   pluginId: P;
 }): BuildPluginApiReturn {
   // Run for checking if the plugin is valid
@@ -24,10 +24,12 @@ export function buildApiPlugin<P extends string>({
   const hono = new OpenAPIHono();
   const cronJobs: BuildPluginApiReturn["cronJobs"] = [];
   modules.forEach(handler => {
-    hono.route(`/${handler.name}`, handler.hono);
+    const moduleInstance = handler.build(pluginId);
 
-    handler.cronJobs?.forEach(cron => {
-      cronJobs.push({ ...cron, module: handler.name });
+    hono.route(`/${moduleInstance.name}`, moduleInstance.hono);
+
+    moduleInstance.cronJobs?.forEach(cron => {
+      cronJobs.push({ ...cron, module: moduleInstance.name });
     });
   });
 

--- a/packages/vitnode/src/api/lib/route.ts
+++ b/packages/vitnode/src/api/lib/route.ts
@@ -1,15 +1,8 @@
 import type { RouteConfig, RouteHandler } from "@hono/zod-openapi";
 
-import { createRoute as createRouteHono } from "@hono/zod-openapi";
-
-import { captchaMiddleware } from "../middlewares/captcha.middleware";
-import {
-  type EnvVitNode,
-  pluginMiddleware,
-} from "../middlewares/global.middleware";
+import type { EnvVitNode } from "../middlewares/global.middleware";
 
 export const buildRoute = <
-  Plugin extends string,
   P extends string,
   R extends Omit<RouteConfig, "path"> & {
     path: P;
@@ -18,43 +11,15 @@ export const buildRoute = <
 >({
   route,
   handler,
-  pluginId,
 }: {
   handler: RouteHandler<R & { path: P }, EnvVitNode>;
-  pluginId: Plugin;
   route: R;
-}): Route<Plugin, R & { path: P }> => {
-  const pluginTag = pluginId
-    .split(/[-_]/)
-    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(" ");
+}): Route<R & { path: P }> => ({
+  route: route as R & { path: P },
+  handler: handler as Route<R & { path: P }>["handler"],
+});
 
-  const tags = [pluginTag, ...(route.tags ?? [])];
-
-  return {
-    route: createRouteHono({
-      tags,
-      middleware: [
-        pluginMiddleware(pluginId),
-        ...(route.withCaptcha ? [captchaMiddleware()] : []),
-        ...(Array.isArray(route.middleware)
-          ? route.middleware
-          : route.middleware
-            ? [route.middleware]
-            : []),
-      ],
-      ...route,
-    }) as R & { path: P },
-    handler: handler as Route<Plugin, R & { path: P }>["handler"],
-    pluginId,
-  };
-};
-
-export interface Route<
-  Plugin extends string = string,
-  R extends RouteConfig = RouteConfig,
-> {
+export interface Route<R extends RouteConfig = RouteConfig> {
   handler: (...args: unknown[]) => Promise<Response> | Response;
-  pluginId: Plugin;
   route: R;
 }

--- a/packages/vitnode/src/api/modules/admin/admin.module.ts
+++ b/packages/vitnode/src/api/modules/admin/admin.module.ts
@@ -7,9 +7,10 @@ import { sessionAdminRoute } from "./routes/session.route";
 import { usersAdminModule } from "./users/users.admin.module";
 
 export const adminModule = buildModule({
-  pluginId: CONFIG_PLUGIN.pluginId,
   name: "admin",
   routes: [sessionAdminRoute],
   modules: [usersAdminModule, debugAdminModule, advancedAdminModule],
   cronJobs: [],
 });
+
+export const adminModuleApi = adminModule.build(CONFIG_PLUGIN.pluginId);

--- a/packages/vitnode/src/api/modules/admin/advanced/advanced.admin.module.ts
+++ b/packages/vitnode/src/api/modules/admin/advanced/advanced.admin.module.ts
@@ -4,8 +4,11 @@ import { CONFIG_PLUGIN } from "@/config";
 import { cronAdminModule } from "./cron/cron.admin.module";
 
 export const advancedAdminModule = buildModule({
-  pluginId: CONFIG_PLUGIN.pluginId,
   name: "advanced",
   routes: [],
   modules: [cronAdminModule],
 });
+
+export const advancedAdminModuleApi = advancedAdminModule.build(
+  CONFIG_PLUGIN.pluginId,
+);

--- a/packages/vitnode/src/api/modules/admin/advanced/cron/cron.admin.module.ts
+++ b/packages/vitnode/src/api/modules/admin/advanced/cron/cron.admin.module.ts
@@ -5,7 +5,8 @@ import { getCronsRoute } from "./routes/get.route";
 import { runCronRoute } from "./routes/run.route";
 
 export const cronAdminModule = buildModule({
-  pluginId: CONFIG_PLUGIN.pluginId,
   name: "cron",
   routes: [getCronsRoute, runCronRoute],
 });
+
+export const cronAdminModuleApi = cronAdminModule.build(CONFIG_PLUGIN.pluginId);

--- a/packages/vitnode/src/api/modules/admin/advanced/cron/routes/get.route.ts
+++ b/packages/vitnode/src/api/modules/admin/advanced/cron/routes/get.route.ts
@@ -6,11 +6,9 @@ import {
   zodPaginationPageInfo,
   zodPaginationQuery,
 } from "@/api/lib/with-pagination";
-import { CONFIG_PLUGIN } from "@/config";
 import { core_cron } from "@/database/cron";
 
 export const getCronsRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "get",
     description: "Get Admin Cron Logs",

--- a/packages/vitnode/src/api/modules/admin/advanced/cron/routes/run.route.ts
+++ b/packages/vitnode/src/api/modules/admin/advanced/cron/routes/run.route.ts
@@ -4,12 +4,10 @@ import { z } from "zod";
 import type { CronJobConfig } from "@/api/lib/cron";
 
 import { buildRoute } from "@/api/lib/route";
-import { CONFIG_PLUGIN } from "@/config";
 import { core_cron } from "@/database/cron";
 import { getNextCronRunDate } from "@/lib/api/get-next-cron-run-date";
 
 export const runCronRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "post",
     description: "Run a specific cron job",

--- a/packages/vitnode/src/api/modules/admin/debug/debug.admin.module.ts
+++ b/packages/vitnode/src/api/modules/admin/debug/debug.admin.module.ts
@@ -3,7 +3,10 @@ import { buildModule } from "../../../lib/module";
 import { logsDebugAdminRoute } from "./routes/logs.route";
 
 export const debugAdminModule = buildModule({
-  pluginId: CONFIG_PLUGIN.pluginId,
   name: "debug",
   routes: [logsDebugAdminRoute],
 });
+
+export const debugAdminModuleApi = debugAdminModule.build(
+  CONFIG_PLUGIN.pluginId,
+);

--- a/packages/vitnode/src/api/modules/admin/debug/routes/logs.route.ts
+++ b/packages/vitnode/src/api/modules/admin/debug/routes/logs.route.ts
@@ -1,7 +1,6 @@
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
-import { CONFIG_PLUGIN } from "@/config";
 import { core_logs } from "@/database/logs";
 
 import { core_users } from "../../../../../database/users";
@@ -13,7 +12,6 @@ import {
 } from "../../../../lib/with-pagination";
 
 export const logsDebugAdminRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "get",
     description: "Get Admin Debug Logs",

--- a/packages/vitnode/src/api/modules/admin/routes/session.route.ts
+++ b/packages/vitnode/src/api/modules/admin/routes/session.route.ts
@@ -5,7 +5,6 @@ import { buildRoute } from "@/api/lib/route";
 import { CONFIG_PLUGIN } from "@/config";
 
 export const sessionAdminRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "get",
     description: "Verify admin session",

--- a/packages/vitnode/src/api/modules/admin/users/routes/list.route.ts
+++ b/packages/vitnode/src/api/modules/admin/users/routes/list.route.ts
@@ -6,11 +6,9 @@ import {
   zodPaginationPageInfo,
   zodPaginationQuery,
 } from "@/api/lib/with-pagination";
-import { CONFIG_PLUGIN } from "@/config";
 import { core_users } from "@/database/users";
 
 export const listUsersAdminRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "get",
     description: "Get list of all users",

--- a/packages/vitnode/src/api/modules/admin/users/routes/users.route.ts
+++ b/packages/vitnode/src/api/modules/admin/users/routes/users.route.ts
@@ -6,11 +6,9 @@ import {
   zodPaginationPageInfo,
   zodPaginationQuery,
 } from "@/api/lib/with-pagination";
-import { CONFIG_PLUGIN } from "@/config";
 import { core_users } from "@/database/users";
 
 export const usersAdminRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "get",
     description: "Get list of all users (Admin only)",

--- a/packages/vitnode/src/api/modules/admin/users/users.admin.module.ts
+++ b/packages/vitnode/src/api/modules/admin/users/users.admin.module.ts
@@ -4,7 +4,10 @@ import { CONFIG_PLUGIN } from "@/config";
 import { listUsersAdminRoute } from "./routes/list.route";
 
 export const usersAdminModule = buildModule({
-  pluginId: CONFIG_PLUGIN.pluginId,
   name: "users",
   routes: [listUsersAdminRoute],
 });
+
+export const usersAdminModuleApi = usersAdminModule.build(
+  CONFIG_PLUGIN.pluginId,
+);

--- a/packages/vitnode/src/api/modules/cron/cron.module.ts
+++ b/packages/vitnode/src/api/modules/cron/cron.module.ts
@@ -5,8 +5,9 @@ import { cleanCron } from "./cron/clean.cron";
 import { runCronRoute } from "./routes/cron.route";
 
 export const cronModule = buildModule({
-  pluginId: CONFIG_PLUGIN.pluginId,
   name: "cron",
   routes: [runCronRoute],
   cronJobs: [cleanCron],
 });
+
+export const cronModuleApi = cronModule.build(CONFIG_PLUGIN.pluginId);

--- a/packages/vitnode/src/api/modules/cron/routes/cron.route.ts
+++ b/packages/vitnode/src/api/modules/cron/routes/cron.route.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 
 import { buildRoute } from "@/api/lib/route";
 import { cronAuthMiddleware } from "@/api/middlewares/cron-auth.middleware";
-import { CONFIG_PLUGIN } from "@/config";
 import { core_cron } from "@/database/cron";
 import { getNextCronRunDate } from "@/lib/api/get-next-cron-run-date";
 
@@ -14,7 +13,6 @@ import {
 } from "../helpers/process-cron-jobs";
 
 export const runCronRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "post",
     description: "Run cron job",

--- a/packages/vitnode/src/api/modules/middleware/middleware.module.ts
+++ b/packages/vitnode/src/api/modules/middleware/middleware.module.ts
@@ -4,7 +4,10 @@ import { CONFIG_PLUGIN } from "@/config";
 import { routeMiddleware } from "./route";
 
 export const middlewareModule = buildModule({
-  pluginId: CONFIG_PLUGIN.pluginId,
   name: "middleware",
   routes: [routeMiddleware],
 });
+
+export const middlewareModuleApi = middlewareModule.build(
+  CONFIG_PLUGIN.pluginId,
+);

--- a/packages/vitnode/src/api/modules/middleware/route.ts
+++ b/packages/vitnode/src/api/modules/middleware/route.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 
 import { buildRoute } from "@/api/lib/route";
-import { CONFIG_PLUGIN } from "@/config";
 
 export const routeMiddlewareSchema = z.object({
   sso: z.array(z.object({ id: z.string(), name: z.string() })),
@@ -15,7 +14,6 @@ export const routeMiddlewareSchema = z.object({
 });
 
 export const routeMiddleware = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     path: "/",
     method: "get",

--- a/packages/vitnode/src/api/modules/users/routes/change-password.route.ts
+++ b/packages/vitnode/src/api/modules/users/routes/change-password.route.ts
@@ -4,7 +4,6 @@ import { z } from "zod";
 
 import { buildRoute } from "@/api/lib/route";
 import { PasswordModel } from "@/api/models/password";
-import { CONFIG_PLUGIN } from "@/config";
 import { core_users, core_users_forgot_password } from "@/database/users";
 
 export const zodChangePasswordSchema = z.object({
@@ -16,7 +15,6 @@ export const zodChangePasswordSchema = z.object({
 });
 
 export const changePasswordRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "post",
     description: "Change user password",

--- a/packages/vitnode/src/api/modules/users/routes/reset-passowrd.route.ts
+++ b/packages/vitnode/src/api/modules/users/routes/reset-passowrd.route.ts
@@ -4,13 +4,11 @@ import { z } from "zod";
 
 import { buildRoute } from "@/api/lib/route";
 import { ForgotPasswordTokenModel } from "@/api/models/password";
-import { CONFIG_PLUGIN } from "@/config";
 import { core_users, core_users_forgot_password } from "@/database/users";
 import ResetPasswordEmailTemplate from "@/emails/reset-password";
 import { CONFIG } from "@/lib/config";
 
 export const resetPasswordRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "post",
     description: "Request a password reset",

--- a/packages/vitnode/src/api/modules/users/routes/session.route.ts
+++ b/packages/vitnode/src/api/modules/users/routes/session.route.ts
@@ -2,10 +2,7 @@ import { z } from "zod";
 
 import { buildRoute } from "@/api/lib/route";
 import { SessionAdminModel } from "@/api/models/session-admin";
-import { CONFIG_PLUGIN } from "@/config";
-
 export const sessionRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "get",
     description: "Verify session",

--- a/packages/vitnode/src/api/modules/users/routes/sign-in.route.ts
+++ b/packages/vitnode/src/api/modules/users/routes/sign-in.route.ts
@@ -4,7 +4,6 @@ import { buildRoute } from "@/api/lib/route";
 import { SessionModel } from "@/api/models/session";
 import { SessionAdminModel } from "@/api/models/session-admin";
 import { UserModel } from "@/api/models/user";
-import { CONFIG_PLUGIN } from "@/config";
 
 export const zodSignInSchema = z.object({
   email: z.email().toLowerCase().openapi({
@@ -19,7 +18,6 @@ export const zodSignInSchema = z.object({
 });
 
 export const signInRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "post",
     description: "Sign in with email and password",

--- a/packages/vitnode/src/api/modules/users/routes/sign-out.route.ts
+++ b/packages/vitnode/src/api/modules/users/routes/sign-out.route.ts
@@ -3,10 +3,8 @@ import { z } from "@hono/zod-openapi";
 import { buildRoute } from "@/api/lib/route";
 import { SessionModel } from "@/api/models/session";
 import { SessionAdminModel } from "@/api/models/session-admin";
-import { CONFIG_PLUGIN } from "@/config";
 
 export const signOutRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "delete",
     description: "Sign out the current admin",

--- a/packages/vitnode/src/api/modules/users/routes/sign-up.route.ts
+++ b/packages/vitnode/src/api/modules/users/routes/sign-up.route.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 import { buildRoute } from "@/api/lib/route";
 import { PasswordModel } from "@/api/models/password";
 import { UserModel } from "@/api/models/user";
-import { CONFIG_PLUGIN } from "@/config";
 
 import { SessionModel } from "../../../models/session";
 
@@ -27,7 +26,6 @@ export const zodSignUpSchema = z.object({
 });
 
 export const signUpRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "post",
     description: "Create a new user",

--- a/packages/vitnode/src/api/modules/users/routes/test.route.ts
+++ b/packages/vitnode/src/api/modules/users/routes/test.route.ts
@@ -1,10 +1,8 @@
 import { z } from "zod";
 
 import { buildRoute } from "@/api/lib/route";
-import { CONFIG_PLUGIN } from "@/config";
 
 export const testRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "post",
     description: "Test route",

--- a/packages/vitnode/src/api/modules/users/sso/routes/callback.route.ts
+++ b/packages/vitnode/src/api/modules/users/sso/routes/callback.route.ts
@@ -3,10 +3,8 @@ import { z } from "zod";
 import { buildRoute } from "@/api/lib/route";
 import { SessionModel } from "@/api/models/session";
 import { SSOModel } from "@/api/models/sso";
-import { CONFIG_PLUGIN } from "@/config";
 
 export const callbackRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "get",
     description: "SSO Callback",

--- a/packages/vitnode/src/api/modules/users/sso/routes/create-url.route.ts
+++ b/packages/vitnode/src/api/modules/users/sso/routes/create-url.route.ts
@@ -2,10 +2,8 @@ import { z } from "zod";
 
 import { buildRoute } from "@/api/lib/route";
 import { SSOModel } from "@/api/models/sso";
-import { CONFIG_PLUGIN } from "@/config";
 
 export const createUrlRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "post",
     description: "Generate SSO URL",

--- a/packages/vitnode/src/api/modules/users/sso/sso.module.ts
+++ b/packages/vitnode/src/api/modules/users/sso/sso.module.ts
@@ -5,7 +5,8 @@ import { callbackRoute } from "./routes/callback.route";
 import { createUrlRoute } from "./routes/create-url.route";
 
 export const ssoUserModule = buildModule({
-  pluginId: CONFIG_PLUGIN.pluginId,
   name: "sso",
   routes: [callbackRoute, createUrlRoute],
 });
+
+export const ssoUserModuleApi = ssoUserModule.build(CONFIG_PLUGIN.pluginId);

--- a/packages/vitnode/src/api/modules/users/users.module.ts
+++ b/packages/vitnode/src/api/modules/users/users.module.ts
@@ -11,7 +11,6 @@ import { testRoute } from "./routes/test.route";
 import { ssoUserModule } from "./sso/sso.module";
 
 export const usersModule = buildModule({
-  pluginId: CONFIG_PLUGIN.pluginId,
   name: "users",
   routes: [
     sessionRoute,
@@ -24,3 +23,5 @@ export const usersModule = buildModule({
   ],
   modules: [ssoUserModule],
 });
+
+export const usersModuleApi = usersModule.build(CONFIG_PLUGIN.pluginId);

--- a/packages/vitnode/src/lib/api/get-middleware-api.ts
+++ b/packages/vitnode/src/lib/api/get-middleware-api.ts
@@ -1,8 +1,8 @@
-import { middlewareModule } from "@/api/modules/middleware/middleware.module";
+import { middlewareModuleApi } from "@/api/modules/middleware/middleware.module";
 import { fetcher } from "@/lib/fetcher";
 
 export const getMiddlewareApi = async () => {
-  const res = await fetcher(middlewareModule, {
+  const res = await fetcher(middlewareModuleApi, {
     path: "/",
     method: "get",
     module: "middleware",

--- a/packages/vitnode/src/lib/api/get-session-admin-api.ts
+++ b/packages/vitnode/src/lib/api/get-session-admin-api.ts
@@ -1,10 +1,10 @@
-import { adminModule } from "@/api/modules/admin/admin.module";
+import { adminModuleApi } from "@/api/modules/admin/admin.module";
 import { fetcher } from "@/lib/fetcher";
 
 import { redirect } from "../navigation";
 
 export const getSessionAdminApi = async () => {
-  const res = await fetcher(adminModule, {
+  const res = await fetcher(adminModuleApi, {
     path: "/session",
     method: "get",
     module: "admin",

--- a/packages/vitnode/src/lib/api/get-session-api.ts
+++ b/packages/vitnode/src/lib/api/get-session-api.ts
@@ -1,8 +1,8 @@
-import { usersModule } from "@/api/modules/users/users.module";
+import { usersModuleApi } from "@/api/modules/users/users.module";
 import { fetcher } from "@/lib/fetcher";
 
 export const getSessionApi = async () => {
-  const res = await fetcher(usersModule, {
+  const res = await fetcher(usersModuleApi, {
     path: "/session",
     method: "get",
     module: "users",

--- a/packages/vitnode/src/views/admin/views/core/advanced/cron/cron-table-view.tsx
+++ b/packages/vitnode/src/views/admin/views/core/advanced/cron/cron-table-view.tsx
@@ -1,6 +1,6 @@
 import { getTranslations } from "next-intl/server";
 
-import { cronAdminModule } from "@/api/modules/admin/advanced/cron/cron.admin.module";
+import { cronAdminModuleApi } from "@/api/modules/admin/advanced/cron/cron.admin.module";
 import { DateFormat } from "@/components/date-format";
 import {
   DataTable,
@@ -16,7 +16,7 @@ export const CronTableView = async ({
   searchParams: Promise<SearchParamsDataTable>;
 }) => {
   const query = await searchParams;
-  const res = await fetcher(cronAdminModule, {
+  const res = await fetcher(cronAdminModuleApi, {
     path: "/",
     method: "get",
     module: "cron",

--- a/packages/vitnode/src/views/admin/views/core/advanced/cron/run-action/mutation-api.ts
+++ b/packages/vitnode/src/views/admin/views/core/advanced/cron/run-action/mutation-api.ts
@@ -2,11 +2,11 @@
 
 import { revalidatePath } from "next/cache";
 
-import { cronAdminModule } from "@/api/modules/admin/advanced/cron/cron.admin.module";
+import { cronAdminModuleApi } from "@/api/modules/admin/advanced/cron/cron.admin.module";
 import { fetcher } from "@/lib/fetcher";
 
 export const mutationApi = async (id: number) => {
-  const res = await fetcher(cronAdminModule, {
+  const res = await fetcher(cronAdminModuleApi, {
     path: "/{id}",
     method: "post",
     module: "cron",

--- a/packages/vitnode/src/views/admin/views/core/debug/system-logs/system-logs-view.tsx
+++ b/packages/vitnode/src/views/admin/views/core/debug/system-logs/system-logs-view.tsx
@@ -1,6 +1,6 @@
 import { getTranslations } from "next-intl/server";
 
-import { debugAdminModule } from "@/api/modules/admin/debug/debug.admin.module";
+import { debugAdminModuleApi } from "@/api/modules/admin/debug/debug.admin.module";
 import { DateFormat } from "@/components/date-format";
 import { DataTable } from "@/components/table/data-table";
 import { fetcher } from "@/lib/fetcher";
@@ -12,7 +12,7 @@ import { BadgeTypeLog } from "./badges/badge-type-log";
 export const getSystemLogsData = async (
   query: Record<string, string | string[] | undefined>,
 ) => {
-  const res = await fetcher(debugAdminModule, {
+  const res = await fetcher(debugAdminModuleApi, {
     prefixPath: "/admin",
     path: "/logs",
     method: "get",

--- a/packages/vitnode/src/views/admin/views/core/users/users-admin-view.tsx
+++ b/packages/vitnode/src/views/admin/views/core/users/users-admin-view.tsx
@@ -1,7 +1,7 @@
 import { MailIcon } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 
-import { adminModule } from "@/api/modules/admin/admin.module";
+import { adminModuleApi } from "@/api/modules/admin/admin.module";
 import { Avatar } from "@/components/avatar";
 import { DateFormat } from "@/components/date-format";
 import { DataTable } from "@/components/table/data-table";
@@ -19,7 +19,7 @@ export const UsersAdminView = async ({
 }) => {
   const t = await getTranslations("admin.user.list");
   const query = await searchParams;
-  const res = await fetcher(adminModule, {
+  const res = await fetcher(adminModuleApi, {
     path: "/list",
     method: "get",
     module: "admin/users",

--- a/packages/vitnode/src/views/auth/password-reset/change-password-form/mutation-api.ts
+++ b/packages/vitnode/src/views/auth/password-reset/change-password-form/mutation-api.ts
@@ -4,7 +4,7 @@ import type z from "zod";
 
 import type { zodChangePasswordSchema } from "@/api/modules/users/routes/change-password.route";
 
-import { usersModule } from "@/api/modules/users/users.module";
+import { usersModuleApi } from "@/api/modules/users/users.module";
 import { fetcher } from "@/lib/fetcher";
 
 export const mutationApi = async ({
@@ -12,7 +12,7 @@ export const mutationApi = async ({
   token,
   userId,
 }: z.infer<typeof zodChangePasswordSchema>) => {
-  const res = await fetcher(usersModule, {
+  const res = await fetcher(usersModuleApi, {
     module: "users",
     path: "/change-password",
     method: "post",

--- a/packages/vitnode/src/views/auth/password-reset/form/mutation-api.ts
+++ b/packages/vitnode/src/views/auth/password-reset/form/mutation-api.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { usersModule } from "@/api/modules/users/users.module";
+import { usersModuleApi } from "@/api/modules/users/users.module";
 import { fetcher } from "@/lib/fetcher";
 
 export const mutationApi = async ({
@@ -10,7 +10,7 @@ export const mutationApi = async ({
   captchaToken: string;
   email: string;
 }) => {
-  const res = await fetcher(usersModule, {
+  const res = await fetcher(usersModuleApi, {
     module: "users",
     path: "/reset-password",
     method: "post",

--- a/packages/vitnode/src/views/auth/sign-in/form/mutation-api.ts
+++ b/packages/vitnode/src/views/auth/sign-in/form/mutation-api.ts
@@ -6,7 +6,7 @@ import { revalidatePath } from "next/cache";
 
 import type { zodSignInSchema } from "@/api/modules/users/routes/sign-in.route";
 
-import { usersModule } from "@/api/modules/users/users.module";
+import { usersModuleApi } from "@/api/modules/users/users.module";
 import { fetcher } from "@/lib/fetcher";
 import { redirect } from "@/lib/navigation";
 
@@ -15,7 +15,7 @@ export const mutationApi = async (
     isAdmin?: boolean;
   },
 ) => {
-  const res = await fetcher(usersModule, {
+  const res = await fetcher(usersModuleApi, {
     path: "/sign_in",
     method: "post",
     module: "users",

--- a/packages/vitnode/src/views/auth/sign-up/form/mutation-api.ts
+++ b/packages/vitnode/src/views/auth/sign-up/form/mutation-api.ts
@@ -6,7 +6,7 @@ import { revalidatePath } from "next/cache";
 
 import type { zodSignUpSchema } from "@/api/modules/users/routes/sign-up.route";
 
-import { usersModule } from "@/api/modules/users/users.module";
+import { usersModuleApi } from "@/api/modules/users/users.module";
 import { fetcher } from "@/lib/fetcher";
 import { redirect } from "@/lib/navigation";
 
@@ -14,7 +14,7 @@ export const mutationApi = async ({
   captchaToken,
   ...input
 }: z.infer<typeof zodSignUpSchema> & { captchaToken: string }) => {
-  const res = await fetcher(usersModule, {
+  const res = await fetcher(usersModuleApi, {
     path: "/sign_up",
     method: "post",
     module: "users",

--- a/packages/vitnode/src/views/auth/sso/buttons/mutation-api.ts
+++ b/packages/vitnode/src/views/auth/sso/buttons/mutation-api.ts
@@ -1,11 +1,11 @@
 "use server";
 
-import { usersModule } from "@/api/modules/users/users.module";
+import { usersModuleApi } from "@/api/modules/users/users.module";
 import { fetcher } from "@/lib/fetcher";
 import { redirect } from "@/lib/navigation";
 
 export const mutationApi = async (providerId: string) => {
-  const res = await fetcher(usersModule, {
+  const res = await fetcher(usersModuleApi, {
     path: "/{providerId}",
     method: "post",
     module: "users/sso",
@@ -21,6 +21,6 @@ export const mutationApi = async (providerId: string) => {
     return { message: "Something is wrong" };
   }
 
-  const data = await res.json();
+  const data = (await res.json()) as { url: string };
   await redirect(data.url);
 };

--- a/packages/vitnode/src/views/auth/sso/callback/client/mutation-api.ts
+++ b/packages/vitnode/src/views/auth/sso/callback/client/mutation-api.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 
-import { usersModule } from "@/api/modules/users/users.module";
+import { usersModuleApi } from "@/api/modules/users/users.module";
 import { fetcher } from "@/lib/fetcher";
 
 export const mutationApi = async ({
@@ -14,7 +14,7 @@ export const mutationApi = async ({
   providerId: string;
   state: string;
 }) => {
-  const res = await fetcher(usersModule, {
+  const res = await fetcher(usersModuleApi, {
     path: "/{providerId}/callback",
     method: "get",
     module: "users/sso",

--- a/packages/vitnode/src/views/layouts/provider.tsx
+++ b/packages/vitnode/src/views/layouts/provider.tsx
@@ -59,11 +59,11 @@ export const RootProvider = ({
           {...progressBar}
           color={progressBar?.color ?? "var(--primary)"}
           height={progressBar?.height ?? "4px"}
-          shallowRouting={progressBar?.shallowRouting ?? true}
           options={{
             showSpinner: false,
             ...progressBar?.options,
           }}
+          shallowRouting={progressBar?.shallowRouting ?? true}
         >
           {children}
         </ProgressProvider>

--- a/packages/vitnode/src/views/layouts/theme/header/user/auth/log-out-mutation-api.ts
+++ b/packages/vitnode/src/views/layouts/theme/header/user/auth/log-out-mutation-api.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 
-import { usersModule } from "@/api/modules/users/users.module";
+import { usersModuleApi } from "@/api/modules/users/users.module";
 import { fetcher } from "@/lib/fetcher";
 import { redirect } from "@/lib/navigation";
 
@@ -11,7 +11,7 @@ export const logOutMutationApi = async ({
 }: {
   isAdmin?: boolean;
 }) => {
-  const res = await fetcher(usersModule, {
+  const res = await fetcher(usersModuleApi, {
     path: "/sign_out",
     method: "delete",
     allowSaveCookies: true,

--- a/plugins/blog/src/api/modules/admin/admin.module.ts
+++ b/plugins/blog/src/api/modules/admin/admin.module.ts
@@ -5,8 +5,9 @@ import { categoriesAdminModule } from "./categories/categories.admin.module";
 import { postsAdminModule } from "./posts/posts.admin.module";
 
 export const adminModule = buildModule({
-  pluginId: CONFIG_PLUGIN.pluginId,
   name: "admin",
   modules: [categoriesAdminModule, postsAdminModule],
   routes: [],
 });
+
+export const adminModuleApi = adminModule.build(CONFIG_PLUGIN.pluginId);

--- a/plugins/blog/src/api/modules/admin/categories/categories.admin.module.ts
+++ b/plugins/blog/src/api/modules/admin/categories/categories.admin.module.ts
@@ -6,7 +6,10 @@ import { deleteCategoryRoute } from "./routes/delete.route";
 import { editCategoryRoute } from "./routes/edit.route";
 
 export const categoriesAdminModule = buildModule({
-  pluginId: CONFIG_PLUGIN.pluginId,
   name: "categories",
   routes: [createCategoryRoute, editCategoryRoute, deleteCategoryRoute],
 });
+
+export const categoriesAdminModuleApi = categoriesAdminModule.build(
+  CONFIG_PLUGIN.pluginId,
+);

--- a/plugins/blog/src/api/modules/admin/categories/routes/create.route.ts
+++ b/plugins/blog/src/api/modules/admin/categories/routes/create.route.ts
@@ -4,7 +4,6 @@ import { removeSpecialCharacters } from "@vitnode/core/lib/special-characters";
 import { eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 
-import { CONFIG_PLUGIN } from "@/const";
 import { blog_categories } from "@/database/categories";
 
 const zodCategoryResponseSchema = z.object({
@@ -19,7 +18,6 @@ export const zodCreateCategorySchema = z.object({
 });
 
 export const createCategoryRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "post",
     path: "/",
@@ -47,8 +45,11 @@ export const createCategoryRoute = buildRoute({
     },
   },
   handler: async c => {
-    const { title } = c.req.valid("json");
-    const titleSeo = removeSpecialCharacters(title);
+    const { title } = c.req.valid("json") as z.infer<
+      typeof zodCreateCategorySchema
+    >;
+    const titleSeo: string = removeSpecialCharacters(title);
+
     const [titleSEODuplocate] = await c
       .get("db")
       .select({
@@ -69,7 +70,7 @@ export const createCategoryRoute = buildRoute({
       .insert(blog_categories)
       .values({
         title,
-        titleSeo: removeSpecialCharacters(title),
+        titleSeo,
       })
       .returning();
 

--- a/plugins/blog/src/api/modules/admin/categories/routes/delete.route.ts
+++ b/plugins/blog/src/api/modules/admin/categories/routes/delete.route.ts
@@ -3,11 +3,9 @@ import { buildRoute } from "@vitnode/core/api/lib/route";
 import { eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 
-import { CONFIG_PLUGIN } from "@/const";
 import { blog_categories } from "@/database/categories";
 
 export const deleteCategoryRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "delete",
     path: "/{id}",
@@ -26,7 +24,7 @@ export const deleteCategoryRoute = buildRoute({
     },
   },
   handler: async c => {
-    const { id } = c.req.valid("param");
+    const { id } = c.req.valid("param") as { id: number };
 
     const result = await c
       .get("db")

--- a/plugins/blog/src/api/modules/admin/categories/routes/edit.route.ts
+++ b/plugins/blog/src/api/modules/admin/categories/routes/edit.route.ts
@@ -4,7 +4,6 @@ import { removeSpecialCharacters } from "@vitnode/core/lib/special-characters";
 import { eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 
-import { CONFIG_PLUGIN } from "@/const";
 import { blog_categories } from "@/database/categories";
 
 import { zodCreateCategorySchema } from "./create.route";
@@ -17,7 +16,6 @@ const zodCategoryResponseSchema = z.object({
 });
 
 export const editCategoryRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "put",
     path: "/{id}",
@@ -51,9 +49,11 @@ export const editCategoryRoute = buildRoute({
     },
   },
   handler: async c => {
-    const { id } = c.req.valid("param");
-    const { title } = c.req.valid("json");
-    const titleSeo = removeSpecialCharacters(title);
+    const { id } = c.req.valid("param") as { id: number };
+    const { title } = c.req.valid("json") as z.infer<
+      typeof zodCreateCategorySchema
+    >;
+    const titleSeo: string = removeSpecialCharacters(title);
     const [editData] = await c
       .get("db")
       .select({
@@ -90,7 +90,7 @@ export const editCategoryRoute = buildRoute({
       .update(blog_categories)
       .set({
         title,
-        titleSeo: removeSpecialCharacters(title),
+        titleSeo,
       })
       .where(eq(blog_categories.id, id))
       .returning();

--- a/plugins/blog/src/api/modules/admin/posts/posts.admin.module.ts
+++ b/plugins/blog/src/api/modules/admin/posts/posts.admin.module.ts
@@ -6,7 +6,10 @@ import { deletePostRoute } from "./routes/delete.route";
 import { editPostRoute } from "./routes/edit.route";
 
 export const postsAdminModule = buildModule({
-  pluginId: CONFIG_PLUGIN.pluginId,
   name: "posts",
   routes: [editPostRoute, createPostRoute, deletePostRoute],
 });
+
+export const postsAdminModuleApi = postsAdminModule.build(
+  CONFIG_PLUGIN.pluginId,
+);

--- a/plugins/blog/src/api/modules/admin/posts/routes/create.route.ts
+++ b/plugins/blog/src/api/modules/admin/posts/routes/create.route.ts
@@ -4,7 +4,6 @@ import { removeSpecialCharacters } from "@vitnode/core/lib/special-characters";
 import { eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 
-import { CONFIG_PLUGIN } from "@/const";
 import { blog_categories } from "@/database/categories";
 import { blog_posts } from "@/database/posts";
 
@@ -28,7 +27,6 @@ export const zodCreatePostSchema = z.object({
 });
 
 export const createPostRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "post",
     path: "/",
@@ -59,8 +57,10 @@ export const createPostRoute = buildRoute({
     },
   },
   handler: async c => {
-    const { title, content, categoryId } = c.req.valid("json");
-    const titleSeo = removeSpecialCharacters(title);
+    const { title, content, categoryId } = c.req.valid("json") as z.infer<
+      typeof zodCreatePostSchema
+    >;
+    const titleSeo: string = removeSpecialCharacters(title);
 
     // Check if category exists
     const [category] = await c

--- a/plugins/blog/src/api/modules/admin/posts/routes/delete.route.ts
+++ b/plugins/blog/src/api/modules/admin/posts/routes/delete.route.ts
@@ -3,11 +3,9 @@ import { buildRoute } from "@vitnode/core/api/lib/route";
 import { eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 
-import { CONFIG_PLUGIN } from "@/const";
 import { blog_posts } from "@/database/posts";
 
 export const deletePostRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "delete",
     path: "/{id}",
@@ -26,7 +24,7 @@ export const deletePostRoute = buildRoute({
     },
   },
   handler: async c => {
-    const { id } = c.req.valid("param");
+    const { id } = c.req.valid("param") as { id: number };
 
     const result = await c
       .get("db")

--- a/plugins/blog/src/api/modules/admin/posts/routes/edit.route.ts
+++ b/plugins/blog/src/api/modules/admin/posts/routes/edit.route.ts
@@ -4,7 +4,6 @@ import { removeSpecialCharacters } from "@vitnode/core/lib/special-characters";
 import { eq } from "drizzle-orm";
 import { HTTPException } from "hono/http-exception";
 
-import { CONFIG_PLUGIN } from "@/const";
 import { blog_categories } from "@/database/categories";
 import { blog_posts } from "@/database/posts";
 
@@ -21,7 +20,6 @@ const zodPostResponseSchema = z.object({
 });
 
 export const editPostRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "put",
     path: "/{id}",
@@ -55,9 +53,11 @@ export const editPostRoute = buildRoute({
     },
   },
   handler: async c => {
-    const { id } = c.req.valid("param");
-    const { title, content, categoryId } = c.req.valid("json");
-    const titleSeo = removeSpecialCharacters(title);
+    const { id } = c.req.valid("param") as { id: number };
+    const { title, content, categoryId } = c.req.valid("json") as z.infer<
+      typeof zodCreatePostSchema
+    >;
+    const titleSeo: string = removeSpecialCharacters(title);
 
     // Check if post exists
     const [existingPost] = await c

--- a/plugins/blog/src/api/modules/categories/categories.module.ts
+++ b/plugins/blog/src/api/modules/categories/categories.module.ts
@@ -6,7 +6,10 @@ import { categoriesRoute } from "./routes/get.route";
 import { testRoute } from "./test.route";
 
 export const categoriesModule = buildModule({
-  pluginId: CONFIG_PLUGIN.pluginId,
   name: "categories",
   routes: [categoriesRoute, testRoute],
 });
+
+export const categoriesModuleApi = categoriesModule.build(
+  CONFIG_PLUGIN.pluginId,
+);

--- a/plugins/blog/src/api/modules/categories/routes/get.route.ts
+++ b/plugins/blog/src/api/modules/categories/routes/get.route.ts
@@ -7,7 +7,6 @@ import {
 } from "@vitnode/core/api/lib/with-pagination";
 import { and, ilike, type SQL } from "drizzle-orm";
 
-import { CONFIG_PLUGIN } from "@/const";
 import { blog_categories } from "@/database/categories";
 
 const zodCategorySchema = z.object({
@@ -17,17 +16,18 @@ const zodCategorySchema = z.object({
   updatedAt: z.date(),
 });
 
+const zodCategoriesQuerySchema = zodPaginationQuery.extend({
+  order: z.enum(["asc", "desc"]).optional(),
+  orderBy: z.enum(["updatedAt"]).optional(),
+  search: z.string().optional(),
+});
+
 export const categoriesRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "get",
     path: "/",
     request: {
-      query: zodPaginationQuery.extend({
-        order: z.enum(["asc", "desc"]).optional(),
-        orderBy: z.enum(["updatedAt"]).optional(),
-        search: z.string().optional(),
-      }),
+      query: zodCategoriesQuerySchema,
     },
     responses: {
       200: {
@@ -44,7 +44,9 @@ export const categoriesRoute = buildRoute({
     },
   },
   handler: async c => {
-    const query = c.req.valid("query");
+    const query = c.req.valid("query") as z.infer<
+      typeof zodCategoriesQuerySchema
+    >;
 
     const data = await withPagination({
       c,
@@ -53,28 +55,25 @@ export const categoriesRoute = buildRoute({
       },
       primaryCursor: blog_categories.id,
       query: async ({ limit, where, orderBy }) => {
+        const paginationWhere = where as SQL | undefined;
         const searchCondition = query.search
           ? ilike(blog_categories.title, `%${query.search}%`)
           : undefined;
 
         let combinedWhere: SQL | undefined;
-        if (searchCondition) {
-          if (where) {
-            combinedWhere = and(where, searchCondition);
-          } else {
-            combinedWhere = searchCondition;
-          }
+        if (searchCondition && paginationWhere) {
+          combinedWhere = and(paginationWhere, searchCondition);
         } else {
-          combinedWhere = where;
+          combinedWhere = searchCondition ?? paginationWhere;
         }
 
-        return await c
-          .get("db")
-          .select()
-          .from(blog_categories)
-          .where(combinedWhere)
-          .orderBy(orderBy)
-          .limit(limit);
+        const baseQuery = c.get("db").select().from(blog_categories);
+
+        const filteredQuery = combinedWhere
+          ? baseQuery.where(combinedWhere)
+          : baseQuery;
+
+        return await filteredQuery.orderBy(orderBy).limit(limit);
       },
       table: blog_categories,
       orderBy: {

--- a/plugins/blog/src/api/modules/categories/test.route.ts
+++ b/plugins/blog/src/api/modules/categories/test.route.ts
@@ -2,11 +2,9 @@ import { buildRoute } from "@vitnode/core/api/lib/route";
 import { UserModel } from "@vitnode/core/api/models/user";
 import { z } from "zod";
 
-import { CONFIG_PLUGIN } from "@/const";
 import TestTemplateEmail from "@/emails/test-template";
 
 export const testRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "post",
     description: "Test route",

--- a/plugins/blog/src/api/modules/posts/posts.module.ts
+++ b/plugins/blog/src/api/modules/posts/posts.module.ts
@@ -5,7 +5,8 @@ import { CONFIG_PLUGIN } from "@/const";
 import { postsRoute } from "./routes/get.route";
 
 export const postsModule = buildModule({
-  pluginId: CONFIG_PLUGIN.pluginId,
   name: "posts",
   routes: [postsRoute],
 });
+
+export const postsModuleApi = postsModule.build(CONFIG_PLUGIN.pluginId);

--- a/plugins/blog/src/api/modules/posts/routes/get.route.ts
+++ b/plugins/blog/src/api/modules/posts/routes/get.route.ts
@@ -5,9 +5,8 @@ import {
   zodPaginationPageInfo,
   zodPaginationQuery,
 } from "@vitnode/core/api/lib/with-pagination";
-import { eq } from "drizzle-orm";
+import { and, eq, type SQL } from "drizzle-orm";
 
-import { CONFIG_PLUGIN } from "@/const";
 import { blog_categories } from "@/database/categories";
 import { blog_posts } from "@/database/posts";
 
@@ -26,17 +25,18 @@ export const zodPostSchema = z.object({
   }),
 });
 
+const zodPostsQuerySchema = zodPaginationQuery.extend({
+  order: z.enum(["asc", "desc"]).optional(),
+  orderBy: z.enum(["updatedAt", "createdAt"]).optional(),
+  categoryId: z.string().transform(Number).optional(),
+});
+
 export const postsRoute = buildRoute({
-  pluginId: CONFIG_PLUGIN.pluginId,
   route: {
     method: "get",
     path: "/",
     request: {
-      query: zodPaginationQuery.extend({
-        order: z.enum(["asc", "desc"]).optional(),
-        orderBy: z.enum(["updatedAt", "createdAt"]).optional(),
-        categoryId: z.string().transform(Number).optional(),
-      }),
+      query: zodPostsQuerySchema,
     },
     responses: {
       200: {
@@ -53,7 +53,7 @@ export const postsRoute = buildRoute({
     },
   },
   handler: async c => {
-    const query = c.req.valid("query");
+    const query = c.req.valid("query") as z.infer<typeof zodPostsQuerySchema>;
 
     const data = await withPagination({
       c,
@@ -61,8 +61,23 @@ export const postsRoute = buildRoute({
         query,
       },
       primaryCursor: blog_posts.id,
-      query: async ({ limit, where, orderBy }) =>
-        await c
+      query: async ({ limit, where, orderBy }) => {
+        const paginationWhere = where as SQL | undefined;
+
+        let categoryFilter: SQL | undefined;
+        if (typeof query.categoryId === "number") {
+          const categoryIdFilterValue = query.categoryId as number;
+          categoryFilter = eq(blog_posts.categoryId, categoryIdFilterValue);
+        }
+
+        let combinedWhere: SQL | undefined;
+        if (categoryFilter && paginationWhere) {
+          combinedWhere = and(paginationWhere, categoryFilter);
+        } else {
+          combinedWhere = categoryFilter ?? paginationWhere;
+        }
+
+        const baseQuery = c
           .get("db")
           .select({
             id: blog_posts.id,
@@ -82,14 +97,14 @@ export const postsRoute = buildRoute({
           .innerJoin(
             blog_categories,
             eq(blog_posts.categoryId, blog_categories.id),
-          )
-          .where(
-            query.categoryId
-              ? eq(blog_posts.categoryId, query.categoryId)
-              : where,
-          )
-          .orderBy(orderBy)
-          .limit(limit),
+          );
+
+        const filteredQuery = combinedWhere
+          ? baseQuery.where(combinedWhere)
+          : baseQuery;
+
+        return await filteredQuery.orderBy(orderBy).limit(limit);
+      },
       table: blog_posts,
       orderBy: {
         column: query.orderBy

--- a/plugins/blog/src/views/admin/categories/actions/create-edit/create-edit.tsx
+++ b/plugins/blog/src/views/admin/categories/actions/create-edit/create-edit.tsx
@@ -32,17 +32,19 @@ export const CreateEditActionCategoriesAdmin = ({
     form,
   ) => {
     let error = "";
+    const payload = values as z.infer<typeof zodCreateCategorySchema>;
+
     if (data?.id) {
       const mutation = await editMutationApi({
         id: data.id,
-        ...values,
+        ...payload,
       });
 
       if (mutation?.error) {
         error = mutation.error;
       }
     } else {
-      const mutation = await createMutationApi(values);
+      const mutation = await createMutationApi(payload);
 
       if (mutation?.error) {
         error = mutation.error;

--- a/plugins/blog/src/views/admin/categories/actions/create-edit/mutation-api.ts
+++ b/plugins/blog/src/views/admin/categories/actions/create-edit/mutation-api.ts
@@ -7,12 +7,12 @@ import { revalidatePath } from "next/cache";
 
 import type { zodCreateCategorySchema } from "../../../../../api/modules/admin/categories/routes/create.route";
 
-import { categoriesAdminModule } from "../../../../../api/modules/admin/categories/categories.admin.module";
+import { categoriesAdminModuleApi } from "../../../../../api/modules/admin/categories/categories.admin.module";
 
 export const createMutationApi = async (
   body: z.infer<typeof zodCreateCategorySchema>,
 ) => {
-  const res = await fetcher(categoriesAdminModule, {
+  const res = await fetcher(categoriesAdminModuleApi, {
     prefixPath: "/admin",
     method: "post",
     module: "categories",
@@ -36,7 +36,7 @@ export const editMutationApi = async ({
   id,
   ...body
 }: z.infer<typeof zodCreateCategorySchema> & { id: number }) => {
-  const res = await fetcher(categoriesAdminModule, {
+  const res = await fetcher(categoriesAdminModuleApi, {
     prefixPath: "/admin",
     method: "put",
     module: "categories",

--- a/plugins/blog/src/views/admin/categories/table/actions/delete/mutation-api.ts
+++ b/plugins/blog/src/views/admin/categories/table/actions/delete/mutation-api.ts
@@ -3,10 +3,10 @@
 import { fetcher } from "@vitnode/core/lib/fetcher";
 import { revalidatePath } from "next/cache";
 
-import { categoriesAdminModule } from "@/api/modules/admin/categories/categories.admin.module";
+import { categoriesAdminModuleApi } from "@/api/modules/admin/categories/categories.admin.module";
 
 export const mutationApi = async (id: number) => {
-  const res = await fetcher(categoriesAdminModule, {
+  const res = await fetcher(categoriesAdminModuleApi, {
     prefixPath: "/admin",
     method: "delete",
     path: "/{id}",

--- a/plugins/blog/src/views/admin/categories/table/categories-admin-view.tsx
+++ b/plugins/blog/src/views/admin/categories/table/categories-admin-view.tsx
@@ -3,7 +3,7 @@ import { DataTable } from "@vitnode/core/components/table/data-table";
 import { fetcher } from "@vitnode/core/lib/fetcher";
 import { getTranslations } from "next-intl/server";
 
-import { categoriesModule } from "@/api/modules/categories/categories.module";
+import { categoriesModuleApi } from "@/api/modules/categories/categories.module";
 
 import { DeleteAction } from "./actions/delete/delete-action";
 import { EditAction } from "./actions/edit-action";
@@ -15,7 +15,7 @@ export const CategoriesAdminView = async ({
 }) => {
   const t = await getTranslations("@vitnode/blog.admin.categories.table");
   const query = await searchParams;
-  const res = await fetcher(categoriesModule, {
+  const res = await fetcher(categoriesModuleApi, {
     path: "/",
     method: "get",
     module: "categories",

--- a/plugins/blog/src/views/admin/posts/actions/create-edit/create-edit.tsx
+++ b/plugins/blog/src/views/admin/posts/actions/create-edit/create-edit.tsx
@@ -12,9 +12,10 @@ import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { z } from "zod";
 
+import type { zodCreatePostSchema } from "@/api/modules/admin/posts/routes/create.route";
 import type { zodPostSchema } from "@/api/modules/posts/routes/get.route";
 
-import { categoriesModule } from "@/api/modules/categories/categories.module";
+import { categoriesModuleApi } from "@/api/modules/categories/categories.module";
 
 import { createMutationApi, editMutationApi } from "./mutation-api";
 
@@ -55,21 +56,24 @@ export const CreateEditActionPostsAdmin = ({
     form,
   ) => {
     let error = "";
+    const categoryIdValue = values.categoryId.value as string;
+    const payload: z.infer<typeof zodCreatePostSchema> = {
+      title: values.title,
+      content: values.content,
+      categoryId: Number.parseInt(categoryIdValue, 10),
+    };
+
     if (data?.id) {
       const mutation = await editMutationApi({
         id: data.id,
-        ...values,
-        categoryId: parseInt(values.categoryId.value, 10),
+        ...payload,
       });
 
       if (mutation?.error) {
         error = mutation.error;
       }
     } else {
-      const mutation = await createMutationApi({
-        ...values,
-        categoryId: parseInt(values.categoryId.value, 10),
-      });
+      const mutation = await createMutationApi(payload);
 
       if (mutation?.error) {
         error = mutation.error;
@@ -110,7 +114,7 @@ export const CreateEditActionPostsAdmin = ({
           component: props => (
             <AutoFormComboboxAsync
               fetchData={async ({ search }) => {
-                const res = await fetcherClient(categoriesModule, {
+                const res = await fetcherClient(categoriesModuleApi, {
                   path: "/",
                   method: "get",
                   module: "categories",

--- a/plugins/blog/src/views/admin/posts/actions/create-edit/mutation-api.ts
+++ b/plugins/blog/src/views/admin/posts/actions/create-edit/mutation-api.ts
@@ -7,12 +7,12 @@ import { revalidatePath } from "next/cache";
 
 import type { zodCreatePostSchema } from "@/api/modules/admin/posts/routes/create.route";
 
-import { postsAdminModule } from "@/api/modules/admin/posts/posts.admin.module";
+import { postsAdminModuleApi } from "@/api/modules/admin/posts/posts.admin.module";
 
 export const createMutationApi = async (
   body: z.infer<typeof zodCreatePostSchema>,
 ) => {
-  const res = await fetcher(postsAdminModule, {
+  const res = await fetcher(postsAdminModuleApi, {
     prefixPath: "/admin",
     method: "post",
     module: "posts",
@@ -36,7 +36,7 @@ export const editMutationApi = async ({
   id,
   ...body
 }: z.infer<typeof zodCreatePostSchema> & { id: number }) => {
-  const res = await fetcher(postsAdminModule, {
+  const res = await fetcher(postsAdminModuleApi, {
     prefixPath: "/admin",
     method: "put",
     module: "posts",

--- a/plugins/blog/src/views/admin/posts/table/actions/delete/mutation-api.ts
+++ b/plugins/blog/src/views/admin/posts/table/actions/delete/mutation-api.ts
@@ -3,10 +3,10 @@
 import { fetcher } from "@vitnode/core/lib/fetcher";
 import { revalidatePath } from "next/cache";
 
-import { postsAdminModule } from "@/api/modules/admin/posts/posts.admin.module";
+import { postsAdminModuleApi } from "@/api/modules/admin/posts/posts.admin.module";
 
 export const mutationApi = async (id: number) => {
-  const res = await fetcher(postsAdminModule, {
+  const res = await fetcher(postsAdminModuleApi, {
     prefixPath: "/admin",
     method: "delete",
     path: "/{id}",

--- a/plugins/blog/src/views/admin/posts/table/posts-admin-view.tsx
+++ b/plugins/blog/src/views/admin/posts/table/posts-admin-view.tsx
@@ -3,7 +3,7 @@ import { DataTable } from "@vitnode/core/components/table/data-table";
 import { fetcher } from "@vitnode/core/lib/fetcher";
 import { getTranslations } from "next-intl/server";
 
-import { postsModule } from "@/api/modules/posts/posts.module";
+import { postsModuleApi } from "@/api/modules/posts/posts.module";
 
 import { DeleteAction } from "./actions/delete/delete-action";
 import { EditAction } from "./actions/edit-action";
@@ -15,7 +15,7 @@ export const PostsAdminView = async ({
 }) => {
   const t = await getTranslations("@vitnode/blog.admin.posts.table");
   const query = await searchParams;
-  const res = await fetcher(postsModule, {
+  const res = await fetcher(postsModuleApi, {
     path: "/",
     method: "get",
     module: "posts",


### PR DESCRIPTION
## Summary
- add missing type assertions and formatting fixes across the blog plugin API/routes so eslint stops flagging unsafe arguments
- update the docs app components to respect the new lint rules (sorted imports, no forwardRef, typed params) and keep the animated beam refs working
- rerun lint to ensure the repo is clean after the pluginId architectural change

## Testing
- `pnpm lint`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69199bd40aac8324acf5f4bb74e8af44)