### PR TITLE
refactor(events): improve adapter semantics and typing

### DIFF
--- a/packages/vitnode/src/api/adapters/events/local.ts
+++ b/packages/vitnode/src/api/adapters/events/local.ts
@@ -2,9 +2,9 @@ import type { Context } from "hono";
 
 import type { EnvVitNode } from "@/api/middlewares/global.middleware";
 import type {
+  AnyEventEnvelope,
   EventEmitResult,
-  EventEnvelope,
-  EventsApiPlugin,
+  EventsAdapter,
 } from "@/api/models/events";
 
 /**
@@ -14,12 +14,12 @@ import type {
  * on the instance that emitted the event - swap the adapter for a broker to
  * fan out across instances.
  */
-export const LocalEventsAdapter = (): EventsApiPlugin => ({
+export const LocalEventsAdapter = (): EventsAdapter => ({
   name: "local",
 
   publish: async (
     c: Context,
-    envelope: EventEnvelope,
+    envelope: AnyEventEnvelope,
   ): Promise<EventEmitResult> => {
     const listeners = c
       .get("core")

--- a/packages/vitnode/src/api/models/events.ts
+++ b/packages/vitnode/src/api/models/events.ts
@@ -113,6 +113,9 @@ export interface EventsAdapter {
   ) => Promise<EventEmitResult>;
 }
 
+/** @deprecated Use `EventsAdapter` instead. */
+export type EventsApiPlugin = EventsAdapter;
+
 export class EventsModel {
   constructor(c: Context) {
     this.c = c;

--- a/packages/vitnode/src/api/models/events.ts
+++ b/packages/vitnode/src/api/models/events.ts
@@ -71,6 +71,11 @@ export interface EventEnvelope<K extends VitNodeEventName = VitNodeEventName> {
   pluginId: string;
 }
 
+/** A discriminated union of every registered event envelope. */
+export type AnyEventEnvelope = {
+  [K in VitNodeEventName]: EventEnvelope<K>;
+}[VitNodeEventName];
+
 export interface EventEmitFailure {
   error: string;
   /** Listener `name` as declared in `buildEventListener`. */
@@ -88,10 +93,11 @@ export interface EventEmitResult {
   /**
    * `delivered` - listeners ran in-process before `emit()` resolved (the
    * bundled Local adapter). `queued` - the envelope was handed to a broker and
-   * delivery happens out-of-band; `delivered`/`failures` say nothing about the
-   * eventual listener runs.
+   * delivery happens out-of-band. `failed` - the adapter could not publish the
+   * event. For queued and failed events, `delivered`/`failures` do not describe
+   * eventual listener execution.
    */
-  status: "delivered" | "queued";
+  status: "delivered" | "failed" | "queued";
 }
 
 /**
@@ -99,9 +105,12 @@ export interface EventEmitResult {
  * to the listeners registered in `c.get("core").events.listeners`; a broker
  * adapter publishes the envelope and returns `status: "queued"`.
  */
-export interface EventsApiPlugin {
+export interface EventsAdapter {
   name: string;
-  publish: (c: Context, envelope: EventEnvelope) => Promise<EventEmitResult>;
+  publish: (
+    c: Context,
+    envelope: AnyEventEnvelope,
+  ) => Promise<EventEmitResult>;
 }
 
 export class EventsModel {
@@ -111,7 +120,7 @@ export class EventsModel {
 
   protected readonly c: Context;
 
-  private adapter(): EventsApiPlugin {
+  private adapter(): EventsAdapter {
     return this.c.get("core").events.adapter;
   }
 
@@ -143,7 +152,7 @@ export class EventsModel {
     const adapter = this.adapter();
 
     try {
-      return await adapter.publish(this.c, envelope);
+      return await adapter.publish(this.c, envelope as AnyEventEnvelope);
     } catch (err) {
       const error = err instanceof Error ? err.message : String(err);
       await this.c
@@ -154,7 +163,7 @@ export class EventsModel {
 
       return {
         eventId: envelope.eventId,
-        status: "delivered",
+        status: "failed",
         delivered: 0,
         failures: [
           {


### PR DESCRIPTION
## Summary

Improves the Events API introduced in #720 while keeping the existing public configuration compatible.

## Changes

- Add an explicit `failed` emit status for adapter publish failures instead of reporting them as `delivered`.
- Add `AnyEventEnvelope`, a discriminated union of all registered event envelopes, so custom adapters can narrow payload types from `envelope.name`.
- Rename the adapter contract to `EventsAdapter`.
- Keep `EventsApiPlugin` as a deprecated compatibility alias to avoid breaking existing integrations.
- Update the local adapter to use the new adapter and envelope types.

## Why

The previous result status could report `delivered` even when the transport failed before delivering anything. The generic envelope type also lost the relationship between an event name and its payload inside adapter implementations.

## Non-goals

This PR does not introduce distributed delivery, retries, persistent event storage, transaction hooks, or the outbox pattern.

## Validation

The diff is intentionally limited to the event model and local adapter. Automated repository checks should validate formatting, type safety, and tests on the PR.