### PR TITLE
feat: Support bigint and UUID pagination identifiers

### DIFF
--- a/apps/web/content/docs/dev/database/pagination.mdx
+++ b/apps/web/content/docs/dev/database/pagination.mdx
@@ -92,7 +92,8 @@ The route automatically accepts `?cursor=...&first=10` and returns `{ edges, pag
       type: 'PgTable',
     },
     primaryCursor: {
-      description: 'Unique numeric column acting as deterministic tiebreaker.',
+      description:
+        'Integer, bigint or UUID row identifier acting as deterministic tiebreaker.',
       required: true,
       type: 'PaginationCursorColumn',
     },
@@ -120,6 +121,36 @@ The route automatically accepts `?cursor=...&first=10` and returns `{ edges, pag
     },
   }}
 />
+
+---
+
+## Integer, bigint and UUID identifiers
+
+`primaryCursor` accepts integer, bigint and UUID columns. Bigints travel as
+decimal strings inside the opaque cursor, so values above JavaScript's
+safe-integer limit keep their precision. UUIDs stay strings and are validated
+before they reach PostgreSQL.
+
+The order column and the identifier can use different types. A bigint order
+column can take a UUID primary key as its stable tiebreaker:
+
+```ts
+import { bigint, pgTable, uuid } from 'drizzle-orm/pg-core'
+
+const events = pgTable('events', {
+  id: uuid().defaultRandom().primaryKey(),
+  sequence: bigint({ mode: 'bigint' }).notNull(),
+})
+
+await withPagination({
+  // ...
+  primaryCursor: events.id,
+  orderBy: { column: events.sequence, order: 'asc' },
+})
+```
+
+Keep the cursor opaque on the client and hand it back unchanged in the next
+request.
 
 ---
 

--- a/packages/vitnode/src/api/lib/pagination-cursor.test.ts
+++ b/packages/vitnode/src/api/lib/pagination-cursor.test.ts
@@ -5,6 +5,7 @@ import {
   text,
   time,
   timestamp,
+  uuid,
 } from "drizzle-orm/pg-core";
 // @vitest-environment node
 import { HTTPException } from "hono/http-exception";
@@ -12,13 +13,18 @@ import { describe, expect, it } from "vitest";
 
 import { core_users } from "@/database/users";
 
+import type { PaginationCursorColumn } from "./with-pagination";
+
 import {
+  cursorIdentifierForColumn,
+  cursorIdentifierOf,
   cursorValueForColumn,
   cursorValueIsCanonicalText,
   cursorValueOf,
   decodePaginationCursor,
   encodePaginationCursor,
   isCursorSortableColumn,
+  isPaginationIdentifierColumn,
 } from "./pagination-cursor";
 
 const probes = camelCase.table("cursor_probes", {
@@ -28,7 +34,10 @@ const probes = camelCase.table("cursor_probes", {
   day: date(),
   moment: timestamp(),
   tags: text().array("[]"),
+  uuid: uuid(),
 });
+
+const UUID_ID = "0198f6f7-d4a2-7ce1-a2ee-4f5f1f2f3a4b";
 
 const statusOf = (error: unknown): number =>
   error instanceof HTTPException ? error.status : 0;
@@ -44,7 +53,7 @@ describe("encoding", () => {
     expect(
       decodePaginationCursor(encodePaginationCursor(cursor), {
         column: "updatedAt",
-        primaryKey: "id",
+        primary: core_users.id,
       }),
     ).toEqual(cursor);
   });
@@ -66,7 +75,7 @@ describe("encoding", () => {
     expect(
       decodePaginationCursor(encodePaginationCursor(cursor), {
         column: "publishedAt",
-        primaryKey: "id",
+        primary: core_users.id,
       }),
     ).toEqual(cursor);
   });
@@ -81,15 +90,45 @@ describe("encoding", () => {
     expect(
       decodePaginationCursor(encodePaginationCursor(cursor), {
         column: "name",
-        primaryKey: "id",
+        primary: core_users.id,
       }).value,
     ).toEqual(value);
+  });
+
+  it("round-trips a bigint order value with a UUID tiebreaker", () => {
+    const cursor = {
+      column: "big",
+      id: UUID_ID,
+      value: "9007199254740993",
+    };
+
+    expect(
+      decodePaginationCursor(encodePaginationCursor(cursor), {
+        column: "big",
+        primary: probes.uuid,
+      }),
+    ).toEqual(cursor);
+  });
+
+  it("round-trips a bigint identifier without losing precision", () => {
+    const cursor = {
+      column: "big",
+      id: "9007199254740993",
+      value: "9007199254740993",
+    };
+
+    expect(
+      decodePaginationCursor(encodePaginationCursor(cursor), {
+        column: "big",
+        primary: probes.big,
+      }),
+    ).toEqual(cursor);
   });
 });
 
 describe("decoding refuses what it cannot trust", () => {
   const decode = (raw: string, column = "updatedAt") =>
-    decodePaginationCursor(raw, { column, primaryKey: "id" });
+    decodePaginationCursor(raw, { column, primary: core_users.id });
 
   it.each([
     ["garbage", "not-a-cursor!!"],
@@ -149,14 +188,66 @@ describe("decoding refuses what it cannot trust", () => {
 describe("legacy numeric cursors", () => {
   it("still works when the list is ordered by its identifier", () => {
     expect(
-      decodePaginationCursor("42", { column: "id", primaryKey: "id" }),
+      decodePaginationCursor("42", { column: "id", primary: core_users.id }),
     ).toEqual({ column: "id", id: 42, value: 42 });
   });
 
   it("is refused for any other ordering rather than guessed at", () => {
     expect(() =>
-      decodePaginationCursor("42", { column: "updatedAt", primaryKey: "id" }),
+      decodePaginationCursor("42", {
+        column: "updatedAt",
+        primary: core_users.id,
+      }),
     ).toThrow(/cannot be used with the "updatedAt" ordering/);
+  });
+});
+
+describe("cursor identifiers", () => {
+  it("accepts integer, bigint and UUID columns", () => {
+    const columns: PaginationCursorColumn[] = [
+      core_users.id,
+      probes.big,
+      probes.uuid,
+    ];
+
+    expect(columns.every(isPaginationIdentifierColumn)).toBe(true);
+  });
+
+  it("serializes and restores every supported identifier type", () => {
+    expect(cursorIdentifierOf(core_users.id, 42)).toBe(42);
+    expect(cursorIdentifierForColumn(core_users.id, 42)).toBe(42);
+
+    expect(cursorIdentifierOf(probes.big, 9007199254740993n)).toBe(
+      "9007199254740993",
+    );
+    expect(cursorIdentifierForColumn(probes.big, "9007199254740993")).toBe(
+      9007199254740993n,
+    );
+
+    expect(cursorIdentifierOf(probes.uuid, UUID_ID)).toBe(UUID_ID);
+    expect(cursorIdentifierForColumn(probes.uuid, UUID_ID)).toBe(UUID_ID);
+  });
+
+  it.each([
+    ["a bigint sent as a number", probes.big, 42],
+    ["a zero bigint", probes.big, "0"],
+    ["a malformed bigint", probes.big, "42n"],
+    ["a bigint outside PostgreSQL's range", probes.big, "9223372036854775808"],
+    ["a UUID sent as a number", probes.uuid, 42],
+    ["a malformed UUID", probes.uuid, "not-a-uuid"],
+  ])("refuses %s", (_why, column, value) => {
+    expect(() => cursorIdentifierForColumn(column, value)).toThrow(
+      HTTPException,
+    );
+  });
+
+  it("does not treat a legacy numeric cursor as a UUID", () => {
+    expect(() =>
+      decodePaginationCursor("42", {
+        column: "uuid",
+        primary: probes.uuid,
+      }),
+    ).toThrow(HTTPException);
   });
 });
 
@@ -176,6 +267,13 @@ describe("column values", () => {
   it("keeps a string a string", () => {
     expect(cursorValueOf(core_users.name, "Ada")).toBe("Ada");
     expect(cursorValueForColumn(core_users.name, "Ada")).toBe("Ada");
+  });
+
+  it("validates a UUID before it can reach Postgres", () => {
+    expect(cursorValueForColumn(probes.uuid, UUID_ID)).toBe(UUID_ID);
+    expect(() => cursorValueForColumn(probes.uuid, "not-a-uuid")).toThrow(
+      HTTPException,
+    );
   });
 
   it("keeps a number a number", () => {
@@ -273,6 +371,7 @@ describe("a tampered cursor value is refused, never coerced", () => {
       ["a number", 12],
       ["a boolean", false],
       ["whitespace", " 12 "],
+      ["outside PostgreSQL's range", "9223372036854775808"],
     ])("refuses %s", (_why, value) => {
       refuses(probes.big, value);
     });

--- a/packages/vitnode/src/api/lib/pagination-cursor.ts
+++ b/packages/vitnode/src/api/lib/pagination-cursor.ts
@@ -5,16 +5,20 @@ import { HTTPException } from "hono/http-exception";
 /** What an order column's value can be, once it has been through JSON. */
 export type PaginationCursorValue = boolean | null | number | string;
 
+/** Integer, bigint and UUID identifiers all have a JSON-safe wire form. */
+export type PaginationCursorIdentifier = number | string;
+
 export interface PaginationCursor {
   /** The order column this cursor was minted for. */
   column: string;
   /** The row's primary key - the tiebreaker half of the ordered tuple. */
-  id: number;
+  id: PaginationCursorIdentifier;
   /** The order column's value on that row. `null` is a real position. */
   value: PaginationCursorValue;
 }
 
-type CursorKind = "bigint" | "boolean" | "number" | "string" | "temporal";
+type CursorKind =
+  "bigint" | "boolean" | "number" | "string" | "temporal" | "uuid";
 
 const KIND_BY_DATA_TYPE: Record<string, CursorKind> = {
   bigint: "bigint",
@@ -26,6 +30,9 @@ const KIND_BY_DATA_TYPE: Record<string, CursorKind> = {
 
 const baseDataTypeOf = (column: PgColumn): string =>
   column.dataType.split(" ")[0];
+
+const isUuidColumn = (column: PgColumn): boolean =>
+  column.getSQLType().toLowerCase() === "uuid";
 
 const isArrayColumn = (column: PgColumn): boolean => column.dimensions > 0;
 
@@ -58,6 +65,7 @@ export const isCursorSortableColumn = (column: PgColumn): boolean =>
 
 const kindOf = (column: PgColumn): CursorKind => {
   if (!isArrayColumn(column) && temporalTypeOf(column)) return "temporal";
+  if (!isArrayColumn(column) && isUuidColumn(column)) return "uuid";
 
   const kind = isArrayColumn(column)
     ? undefined
@@ -142,6 +150,18 @@ const isRealTemporal = (
 };
 
 const DECIMAL_INTEGER = /^-?\d+$/;
+const POSITIVE_DECIMAL_INTEGER = /^[1-9]\d*$/;
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const PG_BIGINT_MIN = -9223372036854775808n;
+const PG_BIGINT_MAX = 9223372036854775807n;
+
+const postgresBigint = (value: string): bigint | undefined => {
+  const parsed = BigInt(value);
+
+  return parsed >= PG_BIGINT_MIN && parsed <= PG_BIGINT_MAX
+    ? parsed
+    : undefined;
+};
 
 const pad = (value: number, width = 2): string =>
   String(value).padStart(width, "0");
@@ -219,6 +239,10 @@ export const cursorValueOf = (
       if (typeof value === "string") return value;
       break;
     }
+    case "uuid": {
+      if (typeof value === "string" && UUID.test(value)) return value;
+      break;
+    }
     default: {
       if (typeof value === "string") return value;
       break;
@@ -266,7 +290,10 @@ export const cursorValueForColumn = (
         throw badRequest(INVALID_CURSOR);
       }
 
-      return BigInt(value);
+      const parsed = postgresBigint(value);
+      if (parsed === undefined) throw badRequest(INVALID_CURSOR);
+
+      return parsed;
     }
     case "boolean": {
       if (typeof value !== "boolean") throw badRequest(INVALID_CURSOR);
@@ -294,6 +321,13 @@ export const cursorValueForColumn = (
       // Postgres does the parsing - at the precision it stored.
       return value;
     }
+    case "uuid": {
+      if (typeof value !== "string" || !UUID.test(value)) {
+        throw badRequest(INVALID_CURSOR);
+      }
+
+      return value;
+    }
     default: {
       if (typeof value !== "string") throw badRequest(INVALID_CURSOR);
 
@@ -313,6 +347,78 @@ export const cursorValueForColumn = (
  */
 export const cursorValueIsCanonicalText = (column: PgColumn): boolean =>
   kindOf(column) === "temporal";
+
+type IdentifierKind = "bigint" | "number" | "uuid";
+
+const identifierKindOf = (column: PgColumn): IdentifierKind | undefined => {
+  if (isArrayColumn(column)) return undefined;
+  if (isUuidColumn(column)) return "uuid";
+
+  const baseDataType = baseDataTypeOf(column);
+  if (baseDataType === "bigint" || baseDataType === "number") {
+    return baseDataType;
+  }
+
+  return undefined;
+};
+
+export const isPaginationIdentifierColumn = (column: PgColumn): boolean =>
+  identifierKindOf(column) !== undefined;
+
+export const cursorIdentifierOf = (
+  column: PgColumn,
+  value: unknown,
+): PaginationCursorIdentifier => {
+  switch (identifierKindOf(column)) {
+    case "bigint":
+      if (typeof value === "bigint" && value > 0n) return value.toString();
+      break;
+    case "number":
+      if (
+        typeof value === "number" &&
+        Number.isSafeInteger(value) &&
+        value > 0
+      ) {
+        return value;
+      }
+      break;
+    case "uuid":
+      if (typeof value === "string" && UUID.test(value)) return value;
+      break;
+  }
+
+  throw new Error(
+    `Cannot build a pagination cursor from the identifier on "${column.name}".`,
+  );
+};
+
+export const cursorIdentifierForColumn = (
+  column: PgColumn,
+  value: PaginationCursorIdentifier,
+): bigint | number | string => {
+  switch (identifierKindOf(column)) {
+    case "bigint":
+      if (typeof value === "string" && POSITIVE_DECIMAL_INTEGER.test(value)) {
+        const parsed = postgresBigint(value);
+        if (parsed !== undefined) return parsed;
+      }
+      break;
+    case "number":
+      if (
+        typeof value === "number" &&
+        Number.isSafeInteger(value) &&
+        value > 0
+      ) {
+        return value;
+      }
+      break;
+    case "uuid":
+      if (typeof value === "string" && UUID.test(value)) return value;
+      break;
+  }
+
+  throw badRequest(INVALID_CURSOR);
+};
 
 export const encodePaginationCursor = (cursor: PaginationCursor): string =>
   Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url");
@@ -346,18 +452,19 @@ const isCursorValue = (value: unknown): value is PaginationCursorValue =>
  */
 export const decodePaginationCursor = (
   raw: string,
-  { column, primaryKey }: { column: string; primaryKey: string },
+  { column, primary }: { column: string; primary: PgColumn },
 ): PaginationCursor => {
   const trimmed = raw.trim();
   if (trimmed === "") throw badRequest(INVALID_CURSOR);
 
   if (LEGACY_CURSOR.test(trimmed)) {
-    if (column !== primaryKey) {
+    if (column !== primary.name) {
       throw badRequest(
         `This cursor cannot be used with the "${column}" ordering. Start from the first page.`,
       );
     }
     const id = Number(trimmed);
+    cursorIdentifierForColumn(primary, id);
 
     return { column, id, value: id };
   }
@@ -379,13 +486,13 @@ export const decodePaginationCursor = (
   const id = candidate.id;
   if (
     typeof candidate.column !== "string" ||
-    typeof id !== "number" ||
-    !Number.isSafeInteger(id) ||
-    id <= 0 ||
+    (typeof id !== "number" && typeof id !== "string") ||
     !isCursorValue(candidate.value)
   ) {
     throw badRequest(INVALID_CURSOR);
   }
+
+  cursorIdentifierForColumn(primary, id);
 
   if (candidate.column !== column) {
     throw badRequest(

--- a/packages/vitnode/src/api/lib/with-pagination.ts
+++ b/packages/vitnode/src/api/lib/with-pagination.ts
@@ -1,4 +1,9 @@
-import type { ColumnDataNumberConstraint, Placeholder, SQL } from "drizzle-orm";
+import type {
+  ColumnDataBigIntConstraint,
+  ColumnDataNumberConstraint,
+  Placeholder,
+  SQL,
+} from "drizzle-orm";
 import type {
   PgColumn,
   PgColumnBaseConfig,
@@ -28,12 +33,15 @@ import { HTTPException } from "hono/http-exception";
 import type { PaginationCursor } from "./pagination-cursor";
 
 import {
+  cursorIdentifierForColumn,
+  cursorIdentifierOf,
   cursorValueForColumn,
   cursorValueIsCanonicalText,
   cursorValueOf,
   decodePaginationCursor,
   encodePaginationCursor,
   isCursorSortableColumn,
+  isPaginationIdentifierColumn,
 } from "./pagination-cursor";
 
 /** Nobody may ask for more than this in one page, whatever they send. */
@@ -106,10 +114,14 @@ function buildCursorCondition({
   primary: PgColumn;
 }): SQL {
   const after = direction === "asc" ? gt : lt;
+  const identifier = sql`${sql.param(
+    cursorIdentifierForColumn(primary, cursor.id),
+    primary,
+  )}`;
 
   // The identifier is the whole tuple when the list is ordered by it, so there
   // is no second half to compare and no null block to worry about.
-  if (isPrimaryOrder) return after(primary, cursor.id);
+  if (isPrimaryOrder) return after(primary, identifier);
 
   const boundary = boundaryValue(column, cursor);
 
@@ -117,13 +129,13 @@ function buildCursorCondition({
     // NULLS LAST: a null cursor is inside the trailing block, and everything
     // that is not null is already behind us.
     if (cursor.value === null) {
-      return required(and(isNull(column), gt(primary, cursor.id)));
+      return required(and(isNull(column), gt(primary, identifier)));
     }
 
     return required(
       or(
         gt(column, boundary),
-        and(eq(column, boundary), gt(primary, cursor.id)),
+        and(eq(column, boundary), gt(primary, identifier)),
         isNull(column),
       ),
     );
@@ -133,12 +145,15 @@ function buildCursorCondition({
   // that block comes first and every non-null row follows it.
   if (cursor.value === null) {
     return required(
-      or(and(isNull(column), lt(primary, cursor.id)), isNotNull(column)),
+      or(and(isNull(column), lt(primary, identifier)), isNotNull(column)),
     );
   }
 
   return required(
-    or(lt(column, boundary), and(eq(column, boundary), lt(primary, cursor.id))),
+    or(
+      lt(column, boundary),
+      and(eq(column, boundary), lt(primary, identifier)),
+    ),
   );
 }
 
@@ -177,18 +192,24 @@ async function fetchTotalCount(
 }
 
 /**
- * A column that can carry the cursor: any numeric one.
+ * A stable row identifier: an integer, bigint or UUID column.
  *
- * Drizzle refines numeric column types (a `serial` is `number int32`, a
- * `doublePrecision` is `number double`), so the bound admits the whole
- * `number ...` family rather than the bare `number`. The data type is asserted
- * through the config - Drizzle leaves `PgColumn`'s first argument as `any` on
- * built columns, exactly as its own `AnyPgColumn` does.
+ * Drizzle refines these types (`serial` is `number int32`, bigint is
+ * `bigint int64`, UUID is `string uuid`), so the bound includes their refined
+ * forms. The first generic stays broad because built `PgColumn`s expose it that
+ * way, as Drizzle's own `AnyPgColumn` does.
  */
+type PaginationIdentifierDataType =
+  | "bigint"
+  | "number"
+  | "string uuid"
+  | `bigint ${ColumnDataBigIntConstraint}`
+  | `number ${ColumnDataNumberConstraint}`;
+
 export type PaginationCursorColumn = PgColumn<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   any,
-  PgColumnBaseConfig<"number" | `number ${ColumnDataNumberConstraint}`>
+  PgColumnBaseConfig<PaginationIdentifierDataType>
 >;
 
 export async function withPagination<
@@ -257,6 +278,12 @@ export async function withPagination<
   const orderColumn = table[orderName] as PgColumn;
   const isPrimaryOrder = orderName === primaryCursor.name;
 
+  if (!isPaginationIdentifierColumn(primary)) {
+    throw new HTTPException(400, {
+      message: `The "${primaryCursor.name}" primary cursor must be an integer, bigint or UUID column.`,
+    });
+  }
+
   // A column with no total order Postgres and JavaScript agree on cannot be
   // paged at all, so it is refused rather than served for one page and then
   // quietly wrong on the next.
@@ -284,7 +311,7 @@ export async function withPagination<
       ? undefined
       : decodePaginationCursor(rawCursor, {
           column: orderName,
-          primaryKey: primaryCursor.name,
+          primary,
         });
 
   const searchWhere = buildSearchWhere(search, params.query.search);
@@ -336,6 +363,7 @@ export async function withPagination<
     edges: finalEdges,
     orderColumn,
     orderName,
+    primaryColumn: primary,
     primaryName: primaryCursor.name,
   });
 
@@ -394,11 +422,13 @@ function cursorsFrom({
   edges,
   orderColumn,
   orderName,
+  primaryColumn,
   primaryName,
 }: {
   edges: readonly Record<string, unknown>[];
   orderColumn: PgColumn;
   orderName: string;
+  primaryColumn: PgColumn;
   primaryName: string;
 }): { endCursor: null | string; startCursor: null | string } {
   const first = edges[0];
@@ -430,7 +460,7 @@ function cursorsFrom({
   const mint = (row: Record<string, unknown>): string =>
     encodePaginationCursor({
       column: orderName,
-      id: Number(row[primaryName]),
+      id: cursorIdentifierOf(primaryColumn, row[primaryName]),
       value: cursorValueOf(orderColumn, valueOf(row)),
     });
 


### PR DESCRIPTION
## Summary

- allow `primaryCursor` to use integer, bigint, or UUID columns
- preserve bigint precision by storing identifiers as decimal strings in opaque cursors
- validate UUIDs and PostgreSQL bigint bounds before building SQL predicates
- support mixed tuples such as a bigint order column with a UUID tiebreaker
- document the supported identifier types and correct the pagination projection example

## Verification

- `pnpm --filter @vitnode/core test` — 6,164 tests passed
- `pnpm --filter @vitnode/core test:types` — 315 type tests passed, no type errors
- `pnpm --filter @vitnode/core exec tsc -p tsconfig.json --noEmit`
- targeted ESLint checks passed