### PR TITLE
Redesign VitNode homepage, add free pricing, and improve SEO

### DIFF
--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://vitnode.com/sitemap.xml

--- a/apps/web/public/sitemap.xml
+++ b/apps/web/public/sitemap.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://vitnode.com/</loc></url>
+  <url><loc>https://vitnode.com/pricing</loc></url>
+  <url><loc>https://vitnode.com/docs/dev</loc></url>
+  <url><loc>https://vitnode.com/docs/dev/setup</loc></url>
+  <url><loc>https://vitnode.com/docs/dev/plugins/create</loc></url>
+  <url><loc>https://vitnode.com/docs/dev/content-engine</loc></url>
+  <url><loc>https://vitnode.com/docs/dev/plugins/admin</loc></url>
+</urlset>

--- a/apps/web/src/components/main-header.tsx
+++ b/apps/web/src/components/main-header.tsx
@@ -1,6 +1,32 @@
 import { LogoVitNodeBrand } from '@vitnode/core/components/logo-vitnode'
-import { MainHeader as MainHeaderContent } from '@vitnode/core/tanstack/layout'
+import { ThemeSwitcher } from '@vitnode/core/components/switchers/themes/theme-switcher'
+import {
+  LanguageSwitcher,
+  RouterLink,
+  UserHeader,
+} from '@vitnode/core/tanstack/layout'
 
 export const MainHeader = () => (
-  <MainHeaderContent logo={<LogoVitNodeBrand />} />
+  <header className="marketing marketing-header">
+    <a className="marketing-skip-link" href="#main-content">
+      Skip to content
+    </a>
+    <div className="marketing-shell marketing-header-top">
+      <RouterLink aria-label="VitNode home" className="marketing-logo" href="/">
+        <LogoVitNodeBrand />
+      </RouterLink>
+      <nav aria-label="Main navigation" className="marketing-nav">
+        <RouterLink href="/">Overview</RouterLink>
+        <RouterLink href="/pricing">Pricing</RouterLink>
+        <RouterLink href="/docs/dev">Documentation</RouterLink>
+        <RouterLink href="/discover">Discover</RouterLink>
+        <RouterLink href="/search">Search</RouterLink>
+      </nav>
+      <div className="marketing-header-controls">
+        <LanguageSwitcher />
+        <ThemeSwitcher />
+        <UserHeader />
+      </div>
+    </div>
+  </header>
 )

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as DocsRouteImport } from './routes/_docs'
 import { Route as MainRouteImport } from './routes/_main'
 import { Route as LlmsFullDottxtRouteImport } from './routes/llms-full[.]txt'
 import { Route as MainIndexRouteImport } from './routes/_main/index'
+import { Route as MainPricingRouteImport } from './routes/_main/pricing'
 import { Route as ApiSplatRouteImport } from './routes/api/$'
 import { Route as DocsSearchRouteImport } from './routes/docs.search'
 import { Route as DocsDocsIndexRouteImport } from './routes/_docs/docs.index'
@@ -40,6 +41,11 @@ const LlmsFullDottxtRoute = LlmsFullDottxtRouteImport.update({
 const MainIndexRoute = MainIndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => MainRoute,
+} as any)
+const MainPricingRoute = MainPricingRouteImport.update({
+  id: '/pricing',
+  path: '/pricing',
   getParentRoute: () => MainRoute,
 } as any)
 const ApiSplatRoute = ApiSplatRouteImport.update({
@@ -71,6 +77,7 @@ const AdminAdminCoreIndexRoute = AdminAdminCoreIndexRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof MainIndexRoute
   '/llms-full.txt': typeof LlmsFullDottxtRoute
+  '/pricing': typeof MainPricingRoute
   '/api/$': typeof ApiSplatRoute
   '/docs/search': typeof DocsSearchRoute
   '/docs/$': typeof DocsDocsSplatRoute
@@ -80,6 +87,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof MainIndexRoute
   '/llms-full.txt': typeof LlmsFullDottxtRoute
+  '/pricing': typeof MainPricingRoute
   '/api/$': typeof ApiSplatRoute
   '/docs/search': typeof DocsSearchRoute
   '/docs/$': typeof DocsDocsSplatRoute
@@ -92,6 +100,7 @@ export interface FileRoutesById {
   '/_docs': typeof DocsRouteWithChildren
   '/_main': typeof MainRouteWithChildren
   '/llms-full.txt': typeof LlmsFullDottxtRoute
+  '/_main/pricing': typeof MainPricingRoute
   '/api/$': typeof ApiSplatRoute
   '/docs/search': typeof DocsSearchRoute
   '/_main/': typeof MainIndexRoute
@@ -104,6 +113,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/llms-full.txt'
+    | '/pricing'
     | '/api/$'
     | '/docs/search'
     | '/docs/$'
@@ -113,6 +123,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/llms-full.txt'
+    | '/pricing'
     | '/api/$'
     | '/docs/search'
     | '/docs/$'
@@ -124,6 +135,7 @@ export interface FileRouteTypes {
     | '/_docs'
     | '/_main'
     | '/llms-full.txt'
+    | '/_main/pricing'
     | '/api/$'
     | '/docs/search'
     | '/_main/'
@@ -176,6 +188,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof MainIndexRouteImport
+      parentRoute: typeof MainRoute
+    }
+    '/_main/pricing': {
+      id: '/_main/pricing'
+      path: '/pricing'
+      fullPath: '/pricing'
+      preLoaderRoute: typeof MainPricingRouteImport
       parentRoute: typeof MainRoute
     }
     '/api/$': {
@@ -239,10 +258,12 @@ const DocsRouteChildren: DocsRouteChildren = {
 const DocsRouteWithChildren = DocsRoute._addFileChildren(DocsRouteChildren)
 
 interface MainRouteChildren {
+  MainPricingRoute: typeof MainPricingRoute
   MainIndexRoute: typeof MainIndexRoute
 }
 
 const MainRouteChildren: MainRouteChildren = {
+  MainPricingRoute: MainPricingRoute,
   MainIndexRoute: MainIndexRoute,
 }
 

--- a/apps/web/src/routes/_main.tsx
+++ b/apps/web/src/routes/_main.tsx
@@ -6,16 +6,25 @@ import {
 } from '@vitnode/core/tanstack/layout'
 
 import { MainHeader } from '#/components/main-header'
+import { SiteFooter } from '#/site/marketing/footer'
+
+const MainLayout = () => {
+  return (
+    <>
+      <ThemeLayoutContent
+        breadcrumb={<MainBreadcrumb />}
+        header={<MainHeader />}
+      >
+        <div id="main-content" tabIndex={-1}>
+          <Outlet />
+        </div>
+      </ThemeLayoutContent>
+      <SiteFooter />
+    </>
+  )
+}
 
 export const Route = createFileRoute('/_main')({
   loader: async ({ context }) => await loadMainShell(context),
   component: MainLayout,
 })
-
-function MainLayout() {
-  return (
-    <ThemeLayoutContent breadcrumb={<MainBreadcrumb />} header={<MainHeader />}>
-      <Outlet />
-    </ThemeLayoutContent>
-  )
-}

--- a/apps/web/src/routes/_main/index.tsx
+++ b/apps/web/src/routes/_main/index.tsx
@@ -1,20 +1,12 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { RouterLink } from '@vitnode/core/tanstack/layout'
 
-import { pageHead } from '#/lib/page-head'
 import { HomeRouteContent } from '#/site/home/home-content'
-import { HOME_DESCRIPTION, HOME_TITLE } from '#/site/home/metadata'
+import { marketingHead } from '#/site/marketing/metadata'
+
+const HomeRoute = () => <HomeRouteContent LinkComponent={RouterLink} />
 
 export const Route = createFileRoute('/_main/')({
-  head: () =>
-    pageHead({
-      description: HOME_DESCRIPTION,
-      robots: 'index, follow',
-      title: HOME_TITLE,
-    }),
+  head: () => marketingHead('home'),
   component: HomeRoute,
 })
-
-function HomeRoute() {
-  return <HomeRouteContent LinkComponent={RouterLink} />
-}

--- a/apps/web/src/routes/_main/pricing.tsx
+++ b/apps/web/src/routes/_main/pricing.tsx
@@ -1,0 +1,10 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { marketingHead } from '#/site/marketing/metadata'
+import { PricingBreadcrumb, PricingPage } from '#/site/marketing/pricing'
+
+export const Route = createFileRoute('/_main/pricing')({
+  head: () => marketingHead('pricing'),
+  staticData: { breadcrumb: <PricingBreadcrumb /> },
+  component: PricingPage,
+})

--- a/apps/web/src/site/README.md
+++ b/apps/web/src/site/README.md
@@ -1,0 +1,50 @@
+# VitNode marketing pages
+
+The homepage and `/pricing` use the shared marketing styles, navigation, canary
+notice, and footer. The footer is mounted once in the main route layout, so it
+also appears on public plugin pages, discover, search, and member settings.
+Documentation keeps its Fumadocs shell.
+
+## Content
+
+- `home/home-content.tsx`: business benefits, plugins, AdminCP, community access,
+  AI agents, security, deployment options, developer setup, and the maker.
+- `home/visuals.tsx`: the feature bento and illustrative SVG/UI demos. The large
+  AdminCP image is an existing product screenshot; community and agent cards
+  are explicitly illustrative.
+- `home/comparison.tsx`: a dated comparison with links to primary sources.
+  Recheck those sources before changing a check mark or the checked date.
+- `marketing/pricing.tsx`: the free MIT software licence, separately explained
+  infrastructure costs, and frequently asked questions.
+
+Claims follow the canary docs and source. Moderator permissions exist, but a
+dedicated Moderator CP is not shipped. AI experiences require implementation
+and a configured provider. The Vercel guide excludes the built-in WebSocket
+server, local storage, and in-process cron. There is no managed VitNode cloud
+plan or support SLA. Keep these distinctions when editing the copy.
+
+## Accessibility and performance
+
+Content renders on the server, including the hero and feature descriptions.
+Decorative SVGs are hidden from assistive technology, and comparison statuses
+include readable text. SVG animations run once, finish within five seconds,
+and respect reduced motion. They do not add a JavaScript animation dependency.
+Images have dimensions and load lazily below the hero.
+
+Marketing colors are scoped and support light and dark themes. The existing
+theme, language, and account controls remain available. Marketing copy is
+currently English, matching the previous homepage.
+
+## SEO
+
+`marketing/metadata.ts` provides distinct titles, descriptions, Open Graph and
+Twitter text, canonical URLs, and JSON-LD for the homepage and pricing page.
+Structured data describes the actual open-source project, without invented
+ratings or product maturity claims. No social image is added or replaced.
+
+Canonical URLs use the official `https://vitnode.com` origin. Localized URLs
+currently serve the same English marketing content and consolidate to the
+unprefixed canonical. Add translated copy and matching locale canonicals before
+adding hreflang alternates. The public `sitemap.xml` lists the marketing pages
+and main documentation entry points; `robots.txt` advertises it. Keep both in
+sync if canonical routes or the official domain change.

--- a/apps/web/src/site/home/comparison.tsx
+++ b/apps/web/src/site/home/comparison.tsx
@@ -1,0 +1,112 @@
+import { Check } from 'lucide-react'
+
+import { SectionHeading } from '#/site/marketing/shared'
+
+const rows = [
+  { feature: 'Open-source code you can change', values: [true, true, false] },
+  {
+    feature: 'Self-host with no software licence fee',
+    values: [true, true, false],
+  },
+  {
+    feature: 'Install your own server-side plugins',
+    values: [true, true, false],
+  },
+  { feature: 'Member and staff management', values: [true, true, true] },
+  { feature: 'AI integrations', values: [true, true, true] },
+  {
+    feature: 'Ready-to-use discussion & moderation workspace',
+    values: [false, true, true],
+  },
+  {
+    feature: 'Managed hosting sold by the project',
+    values: [false, true, true],
+  },
+]
+
+export const ComparisonSection = () => (
+  <section
+    className="marketing-shell marketing-section"
+    id="compare"
+    aria-labelledby="compare-title"
+  >
+    <SectionHeading
+      eyebrow="Different tools. Different sweet spots."
+      title="Find your kind of community builder."
+      id="compare-title"
+    >
+      Choose VitNode when you want to build a custom community application.
+      Choose an established platform when a ready-made community is the goal.
+    </SectionHeading>
+    <div
+      className="comparison-scroll"
+      role="region"
+      aria-label="Community platform comparison"
+      tabIndex={0}
+    >
+      <table className="comparison-table">
+        <caption className="sr-only">
+          VitNode canary compared with self-hosted Discourse and Circle’s hosted
+          offering, September 5, 2026
+        </caption>
+        <thead>
+          <tr>
+            <th scope="col">What matters to you</th>
+            <th scope="col">
+              VitNode<span>Early canary framework</span>
+            </th>
+            <th scope="col">
+              Discourse<span>Self-hosted / hosted</span>
+            </th>
+            <th scope="col">
+              Circle<span>Hosted platform</span>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map(({ feature, values }) => (
+            <tr key={feature}>
+              <th scope="row">{feature}</th>
+              {values.map((available, index) => (
+                <td key={index}>
+                  <Check
+                    className={available ? 'comparison-yes' : 'comparison-no'}
+                    size={20}
+                    aria-hidden
+                  />
+                  <span className="sr-only">
+                    {available
+                      ? 'Available; setup or plan may apply'
+                      : 'Not offered in this comparison'}
+                  </span>
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+    <div className="comparison-notes">
+      <p>
+        <Check className="comparison-yes" size={16} aria-hidden /> Available{' '}
+        <Check className="comparison-no" size={16} aria-hidden /> Not offered in
+        the compared product
+      </p>
+      <p>
+        Features may need setup, plugins, or a paid plan. VitNode provides AI
+        building blocks, not a ready-made assistant. Moderator permissions are
+        included; a dedicated Moderator CP is not shipped.
+      </p>
+      <p>
+        Checked September 5, 2026. Sources:{' '}
+        <a href="https://www.discourse.org/open-source">
+          Discourse open source
+        </a>
+        , <a href="https://www.discourse.org/">Discourse features</a>,{' '}
+        <a href="https://circle.so/pricing">Circle plans</a>,{' '}
+        <a href="https://circle.so/platform">Circle platform</a>. Self-hosting
+        still has infrastructure costs.
+      </p>
+    </div>
+  </section>
+)

--- a/apps/web/src/site/home/home-content.tsx
+++ b/apps/web/src/site/home/home-content.tsx
@@ -1,37 +1,513 @@
-import { lazy, Suspense } from 'react'
+import {
+  ArrowDown,
+  ArrowRight,
+  Check,
+  Cloud,
+  Code2,
+  Heart,
+  LockKeyhole,
+  ShieldCheck,
+  Sparkles,
+  Users,
+} from 'lucide-react'
 
 import type { SiteLinkComponent } from '#/site/home/site-link'
 
-import { AnimatedBeamHomeSkeleton } from '#/site/home/animated-beam/animated-beam-home-skeleton'
-import { AdminSection } from '#/site/home/sections/admin-panel'
-import { CallToActionSection } from '#/site/home/sections/call-to-action'
-import { HeroSection } from '#/site/home/sections/hero'
-import { PoweringBySection } from '#/site/home/sections/powering-by'
+import adminControlPanel from '#/site/home/assets/admin-control-panel.png'
+import {
+  FeatureGrid,
+  PluginDiagram,
+  CommunityPreview,
+  AgentPreview,
+  SecurityDiagram,
+} from '#/site/home/visuals'
+import { ComparisonSection } from '#/site/home/comparison'
+import {
+  CanaryNotice,
+  MarketingActions,
+  SectionHeading,
+} from '#/site/marketing/shared'
 
-const AnimatedBeamHome = lazy(async () => {
-  const { AnimatedBeamHome: Component } =
-    await import('#/site/home/animated-beam/animated-beam-home')
-
-  return { default: Component }
-})
+const adminFeatures = [
+  {
+    Icon: Users,
+    title: 'People, properly organized',
+    text: 'Manage accounts, roles, and staff access from one familiar place.',
+  },
+  {
+    Icon: Code2,
+    title: 'Your plugins feel at home',
+    text: 'Add screens and navigation alongside the built-in management tools.',
+  },
+  {
+    Icon: ShieldCheck,
+    title: 'The right keys, for the right people',
+    text: 'Grant access by role or staff member, down to specific plugin actions.',
+  },
+]
 
 export const HomeRouteContent = ({
-  LinkComponent,
+  LinkComponent: Link,
 }: {
   LinkComponent: SiteLinkComponent
 }) => (
-  <div className="container mx-auto">
-    <HeroSection
-      LinkComponent={LinkComponent}
-      visual={
-        <Suspense fallback={<AnimatedBeamHomeSkeleton />}>
-          <AnimatedBeamHome LinkComponent={LinkComponent} />
-        </Suspense>
-      }
-    />
-
-    <PoweringBySection />
-    <AdminSection />
-    <CallToActionSection />
+  <div className="marketing" lang="en">
+    <section
+      className="marketing-shell marketing-hero"
+      aria-labelledby="home-title"
+    >
+      <div className="hero-copy">
+        <Link className="canary-pill" href="/docs/dev/setup">
+          <span className="status-dot" /> VitNode 2.0 · Canary{' '}
+          <ArrowRight size={14} aria-hidden />
+        </Link>
+        <p className="eyebrow">The open-source community framework</p>
+        <h1 id="home-title">
+          Your people.
+          <br />
+          Your platform.
+          <br />
+          <span>Your rules.</span>
+        </h1>
+        <p className="hero-description">
+          Turn an audience into a place people belong. Build a customer hub, a
+          knowledge space, or your next big community idea—with the boring bits
+          already invited.
+        </p>
+        <MarketingActions LinkComponent={Link} />
+        <p className="quiet-note">
+          Free & open source. Yours to shape. Even the weird ideas.
+        </p>
+      </div>
+      <div className="hero-visual">
+        <CommunityPreview />
+        <p className="visual-caption">
+          A little preview of what you can build with plugins.
+        </p>
+      </div>
+    </section>
+    <div className="marketing-shell">
+      <CanaryNotice LinkComponent={Link} />
+    </div>
+    <section
+      className="marketing-shell outcomes"
+      aria-label="Why build with VitNode"
+    >
+      {[
+        [
+          'Make knowledge stick',
+          'Give helpful content a home your customers can find again.',
+        ],
+        [
+          'Give your team a head start',
+          'Spend less time rebuilding accounts, admin screens, and permissions.',
+        ],
+        [
+          'Keep your options open',
+          'Own the code and choose the services that fit your business.',
+        ],
+      ].map(([title, description], index) => (
+        <div key={title}>
+          <span className="eyebrow">0{index + 1}</span>
+          <h2>{title}</h2>
+          <p>{description}</p>
+        </div>
+      ))}
+    </section>
+    <section
+      className="marketing-shell marketing-section"
+      id="features"
+      aria-labelledby="features-title"
+    >
+      <SectionHeading
+        eyebrow="Small pieces. Big possibilities."
+        title="The good stuff comes together."
+        id="features-title"
+      >
+        Less time connecting the basics. More time making something your people
+        love.
+      </SectionHeading>
+      <FeatureGrid LinkComponent={Link} />
+    </section>
+    <section
+      className="marketing-band"
+      id="plugins"
+      aria-labelledby="plugins-title"
+    >
+      <div className="marketing-shell marketing-section split-section">
+        <div className="section-copy">
+          <SectionHeading
+            eyebrow="The plugin system"
+            title="Big ideas. Small, swappable pieces."
+            id="plugins-title"
+          >
+            Your community shouldn’t outgrow its own software. Keep each feature
+            together as a plugin, and build on it without turning the whole app
+            upside down.
+          </SectionHeading>
+          <ul className="check-list">
+            <li>
+              <Check aria-hidden /> Keep a feature’s pages, data, and admin
+              tools together.
+            </li>
+            <li>
+              <Check aria-hidden /> Add what your business needs as it grows.
+            </li>
+            <li>
+              <Check aria-hidden /> Reuse your work across projects.
+            </li>
+          </ul>
+          <Link className="text-link" href="/docs/dev/plugins/create">
+            Meet your next plugin <ArrowRight aria-hidden size={16} />
+          </Link>
+        </div>
+        <div className="diagram-panel">
+          <PluginDiagram />
+          <div className="diagram-caption">
+            <span className="status-dot" /> One home for every part of a
+            feature.
+          </div>
+        </div>
+      </div>
+    </section>
+    <section
+      className="marketing-shell marketing-section"
+      id="admincp"
+      aria-labelledby="admin-title"
+    >
+      <div className="section-heading-row">
+        <SectionHeading
+          eyebrow="Admin Control Panel"
+          title="Meet your community’s control room."
+          id="admin-title"
+        >
+          Content, people, permissions, and integrations in one place. Your team
+          gets a workspace. You get fewer “where do I change this?” messages.
+        </SectionHeading>
+        <Link className="text-link" href="/docs/dev/plugins/admin">
+          Explore AdminCP <ArrowRight size={16} aria-hidden />
+        </Link>
+      </div>
+      <figure className="admin-preview">
+        <div className="window-bar">
+          <span className="window-dots" aria-hidden>
+            ● ● ●
+          </span>
+          <span>VitNode / Admin Control Panel</span>
+          <span className="small-label">Actual product</span>
+        </div>
+        <img
+          alt="VitNode AdminCP with its management navigation and debugging tools."
+          decoding="async"
+          height={1392}
+          loading="lazy"
+          src={adminControlPanel}
+          width={2880}
+        />
+        <figcaption>
+          Built-in management, with room for your plugins’ own screens and
+          dashboard widgets.
+        </figcaption>
+      </figure>
+      <div className="three-up">
+        {adminFeatures.map(({ Icon, title, text }) => (
+          <article key={title}>
+            <Icon aria-hidden />
+            <h3>{title}</h3>
+            <p>{text}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+    <section
+      className="marketing-shell marketing-section split-section community-section"
+      id="community"
+      aria-labelledby="community-title"
+    >
+      <div className="section-copy">
+        <SectionHeading
+          eyebrow="Made for people, managed by people"
+          title="A community. With a little less chaos."
+          id="community-title"
+        >
+          Give members a place to belong and staff the access they need. Growing
+          your community shouldn’t mean giving everyone the master key.
+        </SectionHeading>
+        <Link
+          className="text-link"
+          href="/docs/dev/working-with-users/staff-permissions"
+        >
+          See how staff access works <ArrowRight size={16} aria-hidden />
+        </Link>
+      </div>
+      <div className="community-cards">
+        <article>
+          <Users aria-hidden />
+          <div>
+            <h3>Member roles</h3>
+            <p>
+              Organize people into groups and shape access around your
+              community.
+            </p>
+          </div>
+          <span className="small-label">Included</span>
+        </article>
+        <article>
+          <ShieldCheck aria-hidden />
+          <div>
+            <h3>Staff permissions</h3>
+            <p>
+              Separate administrator and moderator privileges, with per-plugin
+              controls.
+            </p>
+          </div>
+          <span className="small-label">Included</span>
+        </article>
+        <article>
+          <LockKeyhole aria-hidden />
+          <div>
+            <h3>Moderator CP</h3>
+            <p>
+              Moderator roles and permissions are here. A dedicated moderation
+              workspace is still ahead.
+            </p>
+          </div>
+          <span className="small-label muted-label">Not shipped</span>
+        </article>
+      </div>
+    </section>
+    <section className="marketing-band" id="ai" aria-labelledby="ai-title">
+      <div className="marketing-shell marketing-section split-section">
+        <AgentPreview />
+        <div className="section-copy">
+          <SectionHeading
+            eyebrow="Built for humans. And their AI agents."
+            title="Give your coding agent a map."
+            id="ai-title"
+          >
+            Readable docs, clear plugin boundaries, and shared conventions help
+            your agent work with your project. Less guessing where things go.
+            More progress you can review.
+          </SectionHeading>
+          <div className="tag-row">
+            <span>Agent instructions</span>
+            <span>Full-text docs</span>
+            <span>Typed building blocks</span>
+          </div>
+          <p className="muted-copy">
+            Building AI into your product? Connect a provider to add summaries,
+            streaming responses, and other useful features through the AI SDK.
+            Your team builds the experience; you choose the model.
+          </p>
+          <div className="inline-links">
+            <Link className="text-link" href="/llms-full.txt">
+              Docs for your agent <ArrowDown size={16} aria-hidden />
+            </Link>
+            <Link className="text-link" href="/docs/dev/ai">
+              Build with AI <ArrowRight size={16} aria-hidden />
+            </Link>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section
+      className="marketing-shell marketing-section split-section"
+      id="security"
+      aria-labelledby="security-title"
+    >
+      <div className="section-copy">
+        <SectionHeading
+          eyebrow="A warmer welcome. A smarter front door."
+          title="Let people in. Keep access in check."
+          id="security-title"
+        >
+          Make joining easier with social sign-in, and protect your community
+          with configurable safeguards.
+        </SectionHeading>
+        <div className="security-list">
+          <div>
+            <h3>SSO & social login</h3>
+            <p>
+              Connect Google, Discord, or Facebook—or write a custom provider
+              adapter.
+            </p>
+          </div>
+          <div>
+            <h3>CAPTCHA & rate limits</h3>
+            <p>
+              Use Cloudflare Turnstile or reCAPTCHA and configure request limits
+              to help reduce abuse.
+            </p>
+          </div>
+          <div>
+            <h3>Permission-aware access</h3>
+            <p>
+              Sessions and staff permissions help protect private actions. Your
+              deployment and plugin checks matter too.
+            </p>
+          </div>
+        </div>
+        <Link className="text-link" href="/docs/dev/advanced/auth">
+          Explore authentication <ArrowRight size={16} aria-hidden />
+        </Link>
+      </div>
+      <div className="diagram-panel security-panel">
+        <SecurityDiagram />
+        <div className="security-links">
+          <Link href="/docs/dev/sso">SSO providers ↗</Link>
+          <Link href="/docs/dev/captcha">CAPTCHA setup ↗</Link>
+        </div>
+      </div>
+    </section>
+    <section
+      className="marketing-shell marketing-section"
+      id="hosting"
+      aria-labelledby="hosting-title"
+    >
+      <SectionHeading
+        eyebrow="Your code. Your choice of address."
+        title="In the cloud. Or on your own turf."
+        id="hosting-title"
+      >
+        Choose where your community lives, and keep control of the code behind
+        it.
+      </SectionHeading>
+      <div className="hosting-grid">
+        <article className="hosting-card">
+          <Cloud aria-hidden />
+          <span className="eyebrow">Bring your cloud</span>
+          <h3>A little less server wrangling.</h3>
+          <p>
+            Deploy with the Vercel guide and choose your database, storage, and
+            other services.
+          </p>
+          <Link className="text-link" href="/docs/dev/deployments/cloud/vercel">
+            Cloud deployment <ArrowRight size={16} aria-hidden />
+          </Link>
+          <p className="quiet-note">
+            Vercel does not run the built-in WebSocket server, local uploads, or
+            in-process cron.
+          </p>
+        </article>
+        <article className="hosting-card">
+          <Code2 aria-hidden />
+          <span className="eyebrow">Self-host</span>
+          <h3>Home is where your server is.</h3>
+          <p>
+            Run on your own infrastructure with long-lived connections, local
+            storage, and full control.
+          </p>
+          <Link className="text-link" href="/docs/dev/deployments/self-hosted">
+            Self-hosting guide <ArrowRight size={16} aria-hidden />
+          </Link>
+          <p className="quiet-note">
+            You manage updates, backups, security, and running costs. The
+            software is free.
+          </p>
+        </article>
+      </div>
+    </section>
+    <ComparisonSection />
+    <section
+      className="marketing-shell marketing-section split-section developer-section"
+      aria-labelledby="developer-title"
+    >
+      <div className="section-copy">
+        <SectionHeading
+          eyebrow="A little something for the builders"
+          title="Less setup déjà vu."
+          id="developer-title"
+        >
+          Start a project, build a plugin, and make it yours. Familiar tools
+          underneath. More of your actual product on top.
+        </SectionHeading>
+        <div className="tag-row">
+          <span>React</span>
+          <span>TanStack Start</span>
+          <span>Hono</span>
+          <span>PostgreSQL</span>
+          <span>TypeScript</span>
+        </div>
+        <Link className="text-link" href="/docs/guides/first-plugin">
+          Build your first plugin <ArrowRight size={16} aria-hidden />
+        </Link>
+      </div>
+      <div className="code-panel">
+        <div className="window-bar">
+          <span>terminal</span>
+          <span>01 / Create your app</span>
+        </div>
+        <pre>
+          <code>
+            <span className="code-comment"># Choose Turborepo for plugins</span>
+            {'\n'}pnpm create vitnode-app@canary{'\n\n'}
+            <span className="code-comment"># Inside your new project</span>
+            {'\n'}pnpm docker:dev{'\n'}pnpm db:migrate{'\n'}pnpm dev
+          </code>
+        </pre>
+        <Link href="/docs/dev/setup">
+          Node.js 22+ · Postgres or Docker · Full setup guide ↗
+        </Link>
+      </div>
+    </section>
+    <section
+      className="marketing-shell marketing-section"
+      id="maker"
+      aria-labelledby="maker-title"
+    >
+      <div className="maker-card">
+        <div className="maker-portrait">
+          <img
+            src="https://avatars.githubusercontent.com/u/58148176?v=4"
+            width={240}
+            height={240}
+            loading="lazy"
+            decoding="async"
+            alt="Maciej Balcerzak, creator of VitNode"
+          />
+          <span className="small-label">
+            <Heart size={14} aria-hidden /> Made by a human
+          </span>
+        </div>
+        <div className="section-copy">
+          <p className="eyebrow">A note from the maker</p>
+          <h2 id="maker-title">
+            Hi, I’m Maciej.
+            <br />
+            <span className="muted-copy">I’m building VitNode.</span>
+          </h2>
+          <p>
+            I want building a community to feel like creating something for
+            people—not signing up to rebuild the same admin panel forever.
+          </p>
+          <p>
+            VitNode is my open-source take on that idea: a shared foundation,
+            room for your own plugins, and the freedom to make it yours. It’s
+            early. Come help shape what happens next.
+          </p>
+          <a className="text-link" href="https://github.com/aXenDeveloper">
+            Maciej Balcerzak · @aXenDeveloper{' '}
+            <ArrowRight size={16} aria-hidden />
+          </a>
+        </div>
+      </div>
+    </section>
+    <section className="marketing-shell marketing-section">
+      <div className="final-cta">
+        <Sparkles aria-hidden />
+        <p className="eyebrow">A good place to start something</p>
+        <h2>
+          Your next community
+          <br />
+          starts with a little curiosity.
+        </h2>
+        <p>Bring an idea. Bring your people later.</p>
+        <MarketingActions LinkComponent={Link} />
+        <Link className="text-link" href="/pricing">
+          Check the price. Spoiler: it’s $0.{' '}
+          <ArrowRight size={16} aria-hidden />
+        </Link>
+      </div>
+    </section>
   </div>
 )

--- a/apps/web/src/site/home/metadata.ts
+++ b/apps/web/src/site/home/metadata.ts
@@ -1,4 +1,4 @@
-export const HOME_TITLE = 'Community Framework for Building Apps'
+export const HOME_TITLE = 'Open-Source Community Framework'
 
 export const HOME_DESCRIPTION =
-  'Build with TanStack Start and Hono.js. It provides a structured, plugin-based architecture with Admin Control Panel that makes development faster and less complex.'
+  'Build a community on your terms with VitNode: plugins, a Content Engine, AdminCP, and AI building blocks. Free and open source. Explore the early canary build.'

--- a/apps/web/src/site/home/visuals.tsx
+++ b/apps/web/src/site/home/visuals.tsx
@@ -1,0 +1,604 @@
+import type { ReactNode } from 'react'
+
+import {
+  ArrowUpRight,
+  Bell,
+  BookOpen,
+  Check,
+  CircleDot,
+  FileText,
+  Globe2,
+  Layers,
+  MessageCircle,
+  Search,
+  Sparkles,
+  Users,
+  Zap,
+} from 'lucide-react'
+
+import type { SiteLinkComponent } from '#/site/home/site-link'
+
+const Svg = ({
+  children,
+  className = '',
+  viewBox = '0 0 320 180',
+}: {
+  children: ReactNode
+  className?: string
+  viewBox?: string
+}) => (
+  <svg
+    className={`feature-svg ${className}`}
+    viewBox={viewBox}
+    fill="none"
+    aria-hidden="true"
+    focusable="false"
+  >
+    {children}
+  </svg>
+)
+
+export const CommunityPreview = () => (
+  <div className="community-preview">
+    <div className="preview-top">
+      <span className="preview-brand">
+        <Layers size={20} aria-hidden /> The good place
+      </span>
+      <span className="small-label">Your community</span>
+    </div>
+    <div className="preview-body">
+      <div className="preview-nav" aria-hidden>
+        <span className="active">
+          <MessageCircle size={16} /> Community
+        </span>
+        <span>
+          <BookOpen size={16} /> Knowledge
+        </span>
+        <span>
+          <Users size={16} /> Members
+        </span>
+        <span>
+          <Sparkles size={16} /> What’s new
+        </span>
+        <div className="preview-nav-bottom">
+          <span className="avatar">Y</span> Yours, by design.
+        </div>
+      </div>
+      <div className="preview-feed">
+        <div className="preview-welcome">
+          <span className="eyebrow">A place to belong</span>
+          <strong>
+            Good people.
+            <br />
+            Great conversations.
+          </strong>
+          <span>Make yourself at home.</span>
+        </div>
+        <div className="preview-post">
+          <div className="post-author">
+            <span className="avatar">JD</span>
+            <div>
+              <strong>Jamie</strong>
+              <span>Just getting started</span>
+            </div>
+            <span className="post-tag">Welcome</span>
+          </div>
+          <p>Found my people. Also, who brought the snacks?</p>
+          <div className="post-reactions">
+            <span>♡ 12</span>
+            <span>
+              <MessageCircle size={14} aria-hidden /> 4 replies
+            </span>
+          </div>
+        </div>
+        <div className="preview-post compact-post">
+          <div className="post-author">
+            <span className="avatar neutral-avatar">AL</span>
+            <div>
+              <strong>Alex</strong>
+              <span>Sharing something useful</span>
+            </div>
+          </div>
+          <p>The guide I wish I had on day one.</p>
+          <span className="resource-link">
+            <FileText size={14} aria-hidden /> Getting started, together ↗
+          </span>
+        </div>
+      </div>
+    </div>
+    <div className="preview-notification">
+      <Bell size={18} aria-hidden />
+      <div>
+        <strong>A little connection. In real time.</strong>
+        <span>Jamie replied to your post.</span>
+      </div>
+      <Check size={16} aria-hidden />
+    </div>
+  </div>
+)
+
+const ContentVisual = () => (
+  <div className="content-visual">
+    <div className="content-toolbar">
+      <span>
+        <Layers size={16} aria-hidden /> Your content studio
+      </span>
+      <span className="small-label">One definition. More done.</span>
+    </div>
+    <div className="content-table">
+      <div className="content-table-head">
+        <span>Content</span>
+        <span>Status</span>
+        <span>Language</span>
+      </div>
+      {[
+        ['A very warm welcome', 'Published', 'EN · PL'],
+        ['The community field guide', 'Draft', 'EN'],
+        ['Something worth sharing', 'Scheduled', 'EN · PL'],
+      ].map(([title, status, language]) => (
+        <div key={title}>
+          <span>
+            <FileText size={16} aria-hidden />
+            {title}
+          </span>
+          <span
+            className={`content-status ${status === 'Published' ? 'published' : ''}`}
+          >
+            {status}
+          </span>
+          <span>{language}</span>
+        </div>
+      ))}
+    </div>
+    <Svg viewBox="0 0 520 100" className="content-flow">
+      <path
+        className="svg-line"
+        d="M85 25 H435 M85 25 V55 M260 25 V55 M435 25 V55"
+      />
+      <path className="svg-signal" d="M85 25 H435" />
+      {['Content', 'Admin screens', 'Search & delivery'].map((label, index) => (
+        <g key={label}>
+          <rect
+            className="svg-surface"
+            x={index * 175 + 15}
+            y="48"
+            width="140"
+            height="36"
+            rx="8"
+          />
+          <text x={index * 175 + 85} y="71">
+            {label}
+          </text>
+        </g>
+      ))}
+    </Svg>
+  </div>
+)
+
+const LanguageVisual = () => (
+  <Svg>
+    <ellipse className="svg-line" cx="160" cy="89" rx="61" ry="61" />
+    <ellipse className="svg-line" cx="160" cy="89" rx="25" ry="61" />
+    <path className="svg-line" d="M101 70 H219 M101 108 H219 M160 28 V150" />
+    <g className="svg-float">
+      <rect
+        className="svg-surface"
+        x="27"
+        y="30"
+        width="95"
+        height="37"
+        rx="9"
+      />
+      <text x="74" y="54">
+        Hello!
+      </text>
+    </g>
+    <g className="svg-float delay-one">
+      <rect
+        className="svg-accent-surface"
+        x="194"
+        y="80"
+        width="103"
+        height="39"
+        rx="9"
+      />
+      <text x="245" y="105">
+        Cześć!
+      </text>
+    </g>
+    <g className="svg-float delay-two">
+      <rect
+        className="svg-surface"
+        x="47"
+        y="124"
+        width="100"
+        height="36"
+        rx="9"
+      />
+      <text x="97" y="147">
+        ¡Hola!
+      </text>
+    </g>
+  </Svg>
+)
+
+const CacheVisual = () => (
+  <Svg>
+    <path
+      className="svg-line"
+      d="M43 123 C100 123 87 48 157 48 S215 123 277 123"
+    />
+    <path
+      className="svg-signal"
+      d="M43 123 C100 123 87 48 157 48 S215 123 277 123"
+    />
+    <rect
+      className="svg-surface"
+      x="112"
+      y="70"
+      width="96"
+      height="49"
+      rx="12"
+    />
+    <path
+      className="svg-accent-stroke"
+      d="M165 78 L147 98 H161 L155 111 L174 91 H160 Z"
+    />
+    <circle className="svg-endpoint" cx="43" cy="123" r="7" />
+    <circle className="svg-endpoint" cx="277" cy="123" r="7" />
+    <text x="160" y="151">
+      Less waiting. More doing.
+    </text>
+  </Svg>
+)
+
+const EventVisual = () => (
+  <Svg>
+    <path
+      className="svg-line"
+      d="M77 88 H151 V38 H248 M151 88 H248 M151 88 V138 H248"
+    />
+    <path
+      className="svg-signal"
+      d="M77 88 H151 V38 H248 M151 88 H248 M151 88 V138 H248"
+    />
+    <rect
+      className="svg-accent-surface"
+      x="25"
+      y="66"
+      width="103"
+      height="44"
+      rx="10"
+    />
+    <text x="76" y="93">
+      Published
+    </text>
+    {['Update search', 'Clear cache', 'Notify people'].map((label, index) => (
+      <g key={label}>
+        <rect
+          className="svg-surface"
+          x="188"
+          y={index * 50 + 19}
+          width="119"
+          height="38"
+          rx="8"
+        />
+        <text x="248" y={index * 50 + 43}>
+          {label}
+        </text>
+      </g>
+    ))}
+  </Svg>
+)
+
+const AiVisual = () => (
+  <Svg>
+    <rect
+      className="svg-surface"
+      x="26"
+      y="23"
+      width="268"
+      height="134"
+      rx="12"
+    />
+    <path className="svg-line" d="M47 52 H237 M47 66 H262 M47 80 H208" />
+    <path
+      className="svg-accent-stroke svg-draw"
+      d="M47 110 H223 M47 124 H168"
+    />
+    <path
+      className="svg-accent-stroke svg-spark"
+      d="M254 95 L258 108 L271 112 L258 116 L254 129 L250 116 L237 112 L250 108 Z"
+    />
+    <circle className="svg-endpoint" cx="277" cy="137" r="3" />
+  </Svg>
+)
+
+const SearchVisual = () => (
+  <Svg>
+    <rect
+      className="svg-surface"
+      x="24"
+      y="18"
+      width="272"
+      height="42"
+      rx="10"
+    />
+    <circle className="svg-accent-stroke" cx="45" cy="36" r="6" />
+    <path className="svg-accent-stroke" d="M49 41 L55 47" />
+    <text className="svg-text-start" x="68" y="44">
+      That really helpful guide…
+    </text>
+    {[83, 112, 141].map((y, index) => (
+      <g className={`svg-float delay-${index === 0 ? 'one' : 'two'}`} key={y}>
+        <rect
+          className="svg-soft"
+          x="26"
+          y={y - 9}
+          width="19"
+          height="19"
+          rx="4"
+        />
+        <path
+          className="svg-line"
+          d={`M58 ${y - 3} H${252 - index * 34} M58 ${y + 6} H${187 - index * 27}`}
+        />
+      </g>
+    ))}
+  </Svg>
+)
+
+const RealtimeVisual = () => (
+  <Svg>
+    <path
+      className="svg-line"
+      d="M39 98 H130 Q147 98 147 80 V61 Q147 46 162 46 H279"
+    />
+    <path
+      className="svg-signal"
+      d="M39 98 H130 Q147 98 147 80 V61 Q147 46 162 46 H279"
+    />
+    <circle className="svg-endpoint" cx="39" cy="98" r="8" />
+    <rect
+      className="svg-surface svg-float"
+      x="90"
+      y="76"
+      width="204"
+      height="73"
+      rx="12"
+    />
+    <text className="svg-text-start" x="109" y="103">
+      You’re in the conversation.
+    </text>
+    <text className="svg-text-start svg-muted-text" x="109" y="127">
+      New reply · just now
+    </text>
+    <circle className="svg-endpoint" cx="279" cy="46" r="6" />
+  </Svg>
+)
+
+const features = [
+  {
+    title: 'Content Engine',
+    heading: 'An idea goes in. A whole lot comes out.',
+    text: 'Articles, guides, directories—give your content a shape and get the tools to manage it. Forms, tables, permissions, drafts, and translations. Less busywork, more publishing.',
+    href: '/docs/dev/content-engine',
+    Icon: Layers,
+    Visual: ContentVisual,
+    wide: true,
+  },
+  {
+    title: 'Internationalization',
+    heading: 'Hello, whole world.',
+    text: 'Make your community feel local with translated interfaces and multilingual content.',
+    href: '/docs/dev/i18n',
+    Icon: Globe2,
+    Visual: LanguageVisual,
+  },
+  {
+    title: 'Cache',
+    heading: 'Skip the encore request.',
+    text: 'Keep repeat visits snappy with app caching and optional Redis-backed data caching.',
+    href: '/docs/dev/cache',
+    Icon: Zap,
+    Visual: CacheVisual,
+  },
+  {
+    title: 'Events',
+    heading: 'One action. Good reactions.',
+    text: 'Let your plugins respond when something happens, so connected workflows stay in step.',
+    href: '/docs/dev/events',
+    Icon: CircleDot,
+    Visual: EventVisual,
+  },
+  {
+    title: 'AI building blocks',
+    heading: 'A little help, on your terms.',
+    text: 'Build summaries, writing tools, and streaming answers with your choice of AI provider.',
+    href: '/docs/dev/ai',
+    Icon: Sparkles,
+    Visual: AiVisual,
+  },
+  {
+    title: 'Search engine',
+    heading: 'Less “where was that?”',
+    text: 'Make useful content discoverable across plugins with Postgres or Elasticsearch search.',
+    href: '/docs/dev/search',
+    Icon: Search,
+    Visual: SearchVisual,
+  },
+  {
+    title: 'WebSockets & notifications',
+    heading: 'Good news travels live.',
+    text: 'Deliver live updates and in-app notifications without asking people to hit refresh. Requires a compatible server.',
+    href: '/docs/dev/websocket',
+    Icon: Bell,
+    Visual: RealtimeVisual,
+  },
+]
+
+export const FeatureGrid = ({
+  LinkComponent: Link,
+}: {
+  LinkComponent: SiteLinkComponent
+}) => (
+  <div className="feature-grid">
+    {features.map(({ title, heading, text, href, Icon, Visual, wide }) => (
+      <article
+        className={`feature-card ${wide ? 'feature-card-wide' : ''}`}
+        key={title}
+      >
+        <div className="feature-card-label">
+          <Icon size={18} aria-hidden />
+          <span>{title}</span>
+          <ArrowUpRight size={16} aria-hidden />
+        </div>
+        <div className="feature-art">
+          <Visual />
+        </div>
+        <div className="feature-card-copy">
+          <h3>
+            <Link href={href}>{heading}</Link>
+          </h3>
+          <p>{text}</p>
+        </div>
+      </article>
+    ))}
+  </div>
+)
+
+export const PluginDiagram = () => (
+  <Svg viewBox="0 0 480 330" className="plugin-diagram">
+    <path
+      className="svg-line"
+      d="M135 67 H240 V265 H345 M240 67 H345 M135 165 H345 M135 265 H240"
+    />
+    <path
+      className="svg-signal"
+      d="M135 67 H240 V265 H345 M240 67 H345 M135 165 H345 M135 265 H240"
+    />
+    {[
+      ['Pages', 25, 43],
+      ['API', 335, 43],
+      ['Content', 25, 141],
+      ['AdminCP', 335, 141],
+      ['Translations', 25, 241],
+      ['Permissions', 335, 241],
+    ].map(([label, x, y]) => (
+      <g key={label}>
+        <rect
+          className="svg-surface"
+          x={Number(x)}
+          y={Number(y)}
+          width="120"
+          height="48"
+          rx="12"
+        />
+        <text x={Number(x) + 60} y={Number(y) + 30}>
+          {label}
+        </text>
+      </g>
+    ))}
+    <rect
+      className="svg-accent-surface"
+      x="179"
+      y="109"
+      width="122"
+      height="112"
+      rx="20"
+    />
+    <path
+      className="svg-accent-stroke"
+      d="M226 139 H236 V133 A6 6 0 0 1 248 133 V139 H258 V151 H264 A6 6 0 0 1 264 163 H258 V175 H246 V169 A6 6 0 0 0 234 169 V175 H222 V163 H216 A6 6 0 0 1 216 151 H226 Z"
+    />
+    <text x="240" y="202">
+      Your plugin
+    </text>
+  </Svg>
+)
+
+export const AgentPreview = () => (
+  <div className="agent-preview">
+    <div className="window-bar">
+      <span>
+        <Sparkles size={16} aria-hidden /> Your AI coding workspace
+      </span>
+      <span className="small-label">Illustration</span>
+    </div>
+    <div className="agent-prompt">
+      Let’s build a knowledge hub for our community.
+    </div>
+    <div className="agent-response">
+      <Sparkles size={18} aria-hidden />
+      <div>
+        <strong>A shared foundation. A clear next step.</strong>
+        <p>
+          Start with the docs, follow the conventions, and keep the feature
+          inside its plugin.
+        </p>
+      </div>
+    </div>
+    <div className="agent-files">
+      {[
+        ['AGENTS.md', 'Project conventions'],
+        ['llms-full.txt', 'The full documentation'],
+        ['plugins/knowledge/', 'Your feature’s home'],
+      ].map(([file, caption]) => (
+        <div key={file}>
+          <FileText size={16} aria-hidden />
+          <code>{file}</code>
+          <span>{caption}</span>
+          <Check size={16} aria-hidden />
+        </div>
+      ))}
+    </div>
+    <Svg viewBox="0 0 360 54">
+      <path className="svg-line" d="M24 27 H336" />
+      <path className="svg-signal" d="M24 27 H336" />
+      <circle className="svg-endpoint" cx="24" cy="27" r="4" />
+      <circle className="svg-endpoint" cx="336" cy="27" r="4" />
+    </Svg>
+    <p className="visual-caption">
+      You bring the agent. VitNode brings the context.
+    </p>
+  </div>
+)
+
+export const SecurityDiagram = () => (
+  <Svg viewBox="0 0 420 350">
+    <path
+      className="svg-line"
+      d="M82 78 H157 M263 78 H338 M82 267 H157 M263 267 H338 M210 88 V134 M210 214 V267"
+    />
+    <circle className="svg-line" cx="210" cy="174" r="109" />
+    <circle className="svg-line" cx="210" cy="174" r="83" />
+    <path
+      className="svg-accent-surface"
+      d="M210 121 L254 139 V171 C254 205 229 223 210 232 C191 223 166 205 166 171 V139 Z"
+    />
+    <path
+      className="svg-accent-stroke svg-draw"
+      d="M189 174 L204 189 L232 160"
+    />
+    {[
+      ['Sign in', 30, 57],
+      ['CAPTCHA', 282, 57],
+      ['Roles', 30, 246],
+      ['Permissions', 282, 246],
+    ].map(([label, x, y]) => (
+      <g key={label}>
+        <rect
+          className="svg-surface"
+          x={Number(x)}
+          y={Number(y)}
+          width="110"
+          height="42"
+          rx="10"
+        />
+        <text x={Number(x) + 55} y={Number(y) + 27}>
+          {label}
+        </text>
+      </g>
+    ))}
+  </Svg>
+)

--- a/apps/web/src/site/marketing/footer.tsx
+++ b/apps/web/src/site/marketing/footer.tsx
@@ -1,0 +1,83 @@
+import { LogoVitNodeBrand } from '@vitnode/core/components/logo-vitnode'
+import { RouterLink } from '@vitnode/core/tanstack/layout'
+
+import { REPOSITORY_URL } from './shared'
+
+const columns = [
+  {
+    title: 'Product',
+    links: [
+      ['Overview', '/'],
+      ['Pricing (free, really)', '/pricing'],
+      ['Content Engine', '/docs/dev/content-engine'],
+      ['Plugin system', '/docs/dev/plugins/create'],
+      ['AdminCP', '/docs/dev/plugins/admin'],
+    ],
+  },
+  {
+    title: 'Build something',
+    links: [
+      ['Get started', '/docs/dev/setup'],
+      ['Documentation', '/docs/dev'],
+      ['AI integration', '/docs/dev/ai'],
+      ['Cloud deployment', '/docs/dev/deployments/cloud/vercel'],
+      ['Self-hosting', '/docs/dev/deployments/self-hosted'],
+    ],
+  },
+  {
+    title: 'Stay curious',
+    links: [
+      ['Discover', '/discover'],
+      ['Search', '/search'],
+      ['Contribute', '/docs/dev/contribution'],
+      ['Docs for AI agents', '/llms-full.txt'],
+    ],
+  },
+]
+
+export const SiteFooter = () => (
+  <footer className="marketing marketing-footer">
+    <div className="marketing-shell">
+      <div className="footer-grid">
+        <div className="footer-brand">
+          <RouterLink
+            href="/"
+            className="marketing-logo"
+            aria-label="VitNode home"
+          >
+            <LogoVitNodeBrand />
+          </RouterLink>
+          <p>
+            A home for your community.
+            <br />A head start for your next idea.
+          </p>
+          <span className="canary-pill">
+            <span className="status-dot" /> Canary · very early build
+          </span>
+        </div>
+        {columns.map(({ title, links }) => (
+          <nav className="footer-column" aria-label={title} key={title}>
+            <h2>{title}</h2>
+            {links.map(([label, href]) => (
+              <RouterLink href={href} key={href}>
+                {label}
+              </RouterLink>
+            ))}
+            {title === 'Stay curious' && <a href={REPOSITORY_URL}>GitHub ↗</a>}
+          </nav>
+        ))}
+      </div>
+      <div className="footer-bottom">
+        <p>
+          Made with care by{' '}
+          <a href="https://github.com/aXenDeveloper">Maciej Balcerzak</a> &
+          contributors.
+        </p>
+        <a href={`${REPOSITORY_URL}/blob/canary/LICENSE`}>
+          Open source · MIT licence ↗
+        </a>
+        <p>All the ambition. None of the licence fees.</p>
+      </div>
+    </div>
+  </footer>
+)

--- a/apps/web/src/site/marketing/links.ts
+++ b/apps/web/src/site/marketing/links.ts
@@ -1,0 +1,1 @@
+export const REPOSITORY_URL = 'https://github.com/aXenDeveloper/vitnode'

--- a/apps/web/src/site/marketing/marketing.css
+++ b/apps/web/src/site/marketing/marketing.css
@@ -1,0 +1,1466 @@
+.marketing {
+  --background: #faf9f6;
+  --foreground: #20231f;
+  --card: #fff;
+  --card-foreground: #20231f;
+  --muted: #f0efeb;
+  --muted-foreground: #656861;
+  --primary: #b94920;
+  --primary-foreground: #fff;
+  --border: #dedfd7;
+  --accent: #f2e9df;
+  --accent-foreground: #753618;
+  --success: #287449;
+  --signal: #ce642e;
+  background: var(--background);
+  color: var(--foreground);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+.dark .marketing {
+  --background: #171a17;
+  --foreground: #f0f1e9;
+  --card: #202420;
+  --card-foreground: #f0f1e9;
+  --muted: #292e28;
+  --muted-foreground: #b0b6ab;
+  --primary: #f4a276;
+  --primary-foreground: #29190f;
+  --border: #373d34;
+  --accent: #38291e;
+  --accent-foreground: #f4b68c;
+  --success: #8bc8a3;
+  --signal: #f4a276;
+}
+.marketing :is(h1, h2, h3, p, figure, ul, pre) {
+  margin: 0;
+}
+.marketing :is(h1, h2, h3) {
+  line-height: 1.12;
+  text-wrap: balance;
+}
+.marketing p {
+  text-wrap: pretty;
+}
+.marketing :is(a, button, [tabindex]):focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 5px;
+  border-radius: 0.25rem;
+}
+.marketing section[id] {
+  scroll-margin-top: 8rem;
+}
+.marketing-shell {
+  width: min(100% - 3rem, 75rem);
+  margin-inline: auto;
+}
+.marketing-section {
+  padding-block: 5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+.marketing .eyebrow {
+  font-size: 0.875rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  color: var(--primary);
+}
+.marketing h2 {
+  font-size: clamp(2rem, 3.6vw, 3.25rem);
+  font-weight: 550;
+  letter-spacing: -0.045em;
+}
+.marketing h3 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: -0.025em;
+}
+.marketing .muted-copy,
+.marketing .quiet-note,
+.marketing .visual-caption {
+  color: var(--muted-foreground);
+}
+.marketing .quiet-note,
+.marketing .visual-caption {
+  font-size: 0.875rem;
+}
+.marketing .visual-caption {
+  text-align: center;
+}
+.marketing .text-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  font-size: 0.9375rem;
+  width: fit-content;
+  text-decoration: none;
+}
+.marketing .text-link:hover {
+  color: var(--primary);
+}
+.marketing .text-link svg {
+  transition: transform 0.2s ease;
+  flex-shrink: 0;
+}
+.marketing .text-link:hover svg {
+  transform: translateX(3px);
+}
+.marketing-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+.marketing-actions a {
+  min-height: 3rem;
+  padding-inline: 1.25rem;
+  font-size: 0.9375rem;
+}
+.marketing-hero {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  align-items: center;
+  gap: 3rem;
+  padding-block: 5rem 4rem;
+}
+.hero-copy {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1.5rem;
+}
+.hero-copy h1 {
+  font-size: clamp(3.5rem, 6vw, 5.5rem);
+  letter-spacing: -0.065em;
+  font-weight: 550;
+  line-height: 1.02;
+}
+.hero-copy h1 span {
+  color: var(--primary);
+}
+.hero-description {
+  color: var(--muted-foreground);
+  font-size: 1.125rem;
+  max-width: 31rem;
+}
+.canary-pill {
+  border: 1px solid var(--border);
+  border-radius: 2rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  background: var(--card);
+  color: var(--foreground);
+  padding: 0.375rem 0.75rem;
+}
+.status-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  display: inline-block;
+  background: var(--signal);
+  flex-shrink: 0;
+}
+.hero-visual {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-width: 0;
+}
+.community-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  background: var(--card);
+  color: var(--card-foreground);
+  box-shadow: 0 1rem 3rem -1rem #20231f20;
+  overflow: hidden;
+  transform: rotate(-1deg);
+}
+.preview-top,
+.preview-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.preview-top {
+  padding: 1rem;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.875rem;
+}
+.preview-brand {
+  font-weight: 600;
+}
+.preview-brand svg {
+  color: var(--primary);
+}
+.small-label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--success);
+  background: color-mix(in srgb, var(--success) 8%, transparent);
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.375rem;
+  white-space: nowrap;
+}
+.muted-label {
+  color: var(--muted-foreground);
+  background: var(--muted);
+}
+.preview-body {
+  display: grid;
+  grid-template-columns: 9rem 1fr;
+}
+.preview-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  border-right: 1px solid var(--border);
+  padding: 1rem 0.5rem;
+  font-size: 0.875rem;
+  color: var(--muted-foreground);
+}
+.preview-nav > span {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  white-space: nowrap;
+}
+.preview-nav .active {
+  background: var(--accent);
+  color: var(--accent-foreground);
+  border-radius: 0.375rem;
+}
+.preview-nav-bottom {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.5rem;
+}
+.preview-feed {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-width: 0;
+}
+.preview-welcome {
+  background: var(--accent);
+  color: var(--accent-foreground);
+  border: 1px solid color-mix(in srgb, var(--primary) 12%, transparent);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+}
+.preview-welcome strong {
+  font-size: 1.625rem;
+  line-height: 1.15;
+  letter-spacing: -0.035em;
+  font-weight: 550;
+}
+.preview-post {
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  font-size: 0.875rem;
+}
+.post-author {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.post-author > div {
+  display: flex;
+  flex-direction: column;
+}
+.post-author > div > span {
+  color: var(--muted-foreground);
+}
+.avatar {
+  display: grid;
+  place-items: center;
+  width: 2rem;
+  height: 2rem;
+  flex-shrink: 0;
+  background: var(--accent);
+  color: var(--accent-foreground);
+  font-size: 0.875rem;
+  border-radius: 50%;
+}
+.neutral-avatar {
+  background: var(--muted);
+  color: var(--foreground);
+}
+.post-tag {
+  margin-left: auto;
+  font-size: 0.875rem;
+  color: var(--success);
+}
+.post-reactions {
+  display: flex;
+  gap: 1rem;
+  color: var(--muted-foreground);
+}
+.post-reactions span,
+.resource-link {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+.resource-link {
+  color: var(--primary);
+}
+.preview-notification {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-top: 1px solid var(--border);
+  background: var(--muted);
+  color: var(--foreground);
+  animation: notification-in 0.7s ease both;
+}
+.preview-notification > svg {
+  flex-shrink: 0;
+  color: var(--success);
+}
+.preview-notification > div {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.875rem;
+  flex: 1;
+}
+.preview-notification span {
+  color: var(--muted-foreground);
+}
+.canary-notice {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  border: 1px solid color-mix(in srgb, var(--primary) 20%, var(--border));
+  border-radius: 0.75rem;
+  padding: 1.25rem 1.5rem;
+  background: var(--accent);
+  color: var(--accent-foreground);
+}
+.canary-notice > svg {
+  flex-shrink: 0;
+}
+.canary-notice strong {
+  font-size: 1rem;
+}
+.canary-notice p {
+  font-size: 0.875rem;
+}
+.canary-notice a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+.outcomes {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 2.5rem;
+  padding-block: 3rem;
+  border-bottom: 1px solid var(--border);
+}
+.outcomes > div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+.outcomes h2 {
+  font-size: 1.125rem;
+  letter-spacing: -0.025em;
+}
+.outcomes p {
+  font-size: 0.9375rem;
+  color: var(--muted-foreground);
+}
+.section-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 43rem;
+}
+.section-heading > p:last-child {
+  color: var(--muted-foreground);
+  font-size: 1.0625rem;
+  max-width: 39rem;
+}
+.section-heading-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 2rem;
+}
+.section-heading-row > a {
+  flex-shrink: 0;
+}
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+.feature-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  background: var(--card);
+  color: var(--card-foreground);
+  overflow: hidden;
+  padding: 1.5rem;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease;
+}
+.feature-card:hover {
+  border-color: color-mix(in srgb, var(--primary) 45%, var(--border));
+  box-shadow: 0 0.75rem 2rem -1rem #20231f20;
+}
+.feature-card-wide {
+  grid-column: span 2;
+}
+.feature-card-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--muted-foreground);
+  font-weight: 500;
+}
+.feature-card-label > svg:first-child {
+  color: var(--primary);
+}
+.feature-card-label > svg:last-child {
+  margin-left: auto;
+}
+.feature-card-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: auto;
+}
+.feature-card-copy p {
+  color: var(--muted-foreground);
+  font-size: 0.9375rem;
+}
+.feature-art {
+  display: grid;
+  place-items: center;
+  min-height: 11rem;
+}
+.feature-svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  overflow: visible;
+}
+.feature-svg text {
+  fill: var(--foreground);
+  text-anchor: middle;
+  font-family: inherit;
+  font-size: 14px;
+}
+.feature-svg .svg-text-start {
+  text-anchor: start;
+}
+.feature-svg .svg-muted-text {
+  fill: var(--muted-foreground);
+}
+.svg-line {
+  stroke: var(--border);
+  stroke-width: 1.5;
+  stroke-linecap: round;
+}
+.svg-surface {
+  fill: var(--card);
+  stroke: var(--border);
+}
+.svg-soft {
+  fill: var(--muted);
+}
+.svg-accent-surface {
+  fill: var(--accent);
+  stroke: color-mix(in srgb, var(--primary) 35%, transparent);
+}
+.svg-accent-stroke {
+  stroke: var(--primary);
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.svg-endpoint {
+  fill: var(--signal);
+}
+.svg-signal {
+  stroke: var(--signal);
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-dasharray: 10 180;
+  animation: signal-travel 4s ease-out 1;
+}
+.svg-float {
+  animation: gentle-float 3.5s ease-in-out 1;
+}
+.svg-draw {
+  stroke-dasharray: 220;
+  animation: draw-line 2.5s ease-out 1;
+}
+.svg-spark {
+  transform-origin: center;
+  transform-box: fill-box;
+  animation: gentle-spark 3s ease-in-out 1;
+}
+.delay-one {
+  animation-delay: 0.25s;
+}
+.delay-two {
+  animation-delay: 0.5s;
+}
+.content-visual {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  overflow: hidden;
+  background: var(--background);
+  color: var(--foreground);
+}
+.content-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.875rem;
+}
+.content-toolbar > span:first-child {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.content-table {
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+}
+.content-table > div {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 6rem 5rem;
+  align-items: center;
+  gap: 0.5rem;
+  padding-block: 0.5rem;
+  border-bottom: 1px solid var(--border);
+}
+.content-table > div > span:first-child {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.content-table svg {
+  flex-shrink: 0;
+  color: var(--muted-foreground);
+}
+.content-table-head {
+  color: var(--muted-foreground);
+}
+.content-status {
+  font-size: 0.875rem;
+  color: var(--muted-foreground);
+}
+.content-status.published {
+  color: var(--success);
+}
+.content-flow {
+  max-height: 6rem;
+}
+.marketing-band {
+  border-block: 1px solid var(--border);
+  background: var(--muted);
+  color: var(--foreground);
+}
+.split-section {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  align-items: center;
+  gap: 4rem;
+}
+.section-copy {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1.5rem;
+}
+.section-copy > p:not(.eyebrow) {
+  color: var(--muted-foreground);
+}
+.check-list {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+.check-list li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  font-size: 0.9375rem;
+}
+.check-list svg {
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
+  color: var(--success);
+  margin-top: 0.25rem;
+}
+.diagram-panel {
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  background: var(--card);
+  color: var(--card-foreground);
+  overflow: hidden;
+}
+.diagram-caption {
+  border-top: 1px solid var(--border);
+  padding: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--muted-foreground);
+}
+.admin-preview {
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  background: var(--card);
+  color: var(--card-foreground);
+  overflow: hidden;
+}
+.window-bar {
+  padding: 0.75rem 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.875rem;
+  color: var(--muted-foreground);
+  border-bottom: 1px solid var(--border);
+}
+.window-bar > span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.window-dots {
+  letter-spacing: 0.125rem;
+}
+.admin-preview img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+.admin-preview figcaption {
+  padding: 1rem;
+  border-top: 1px solid var(--border);
+  color: var(--muted-foreground);
+  font-size: 0.875rem;
+}
+.three-up {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 2rem;
+}
+.three-up article {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+.three-up svg {
+  color: var(--primary);
+}
+.three-up p {
+  color: var(--muted-foreground);
+  font-size: 0.9375rem;
+}
+.three-up h3 {
+  font-size: 1.0625rem;
+}
+.community-section {
+  border-top: 1px solid var(--border);
+}
+.community-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+.community-cards article {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  padding: 1.25rem;
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  background: var(--card);
+  color: var(--card-foreground);
+}
+.community-cards article > div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.community-cards article > svg {
+  color: var(--primary);
+  width: 1.25rem;
+}
+.community-cards article > .small-label {
+  grid-column: 2;
+  justify-self: start;
+}
+.community-cards h3 {
+  font-size: 1.0625rem;
+}
+.community-cards p {
+  font-size: 0.9375rem;
+  color: var(--muted-foreground);
+}
+.tag-row,
+.inline-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+.tag-row span {
+  border: 1px solid var(--border);
+  background: var(--card);
+  color: var(--card-foreground);
+  border-radius: 0.375rem;
+  padding: 0.375rem 0.625rem;
+  font-size: 0.875rem;
+}
+.inline-links {
+  gap: 1.5rem;
+}
+.agent-preview {
+  border: 1px solid var(--border);
+  background: var(--card);
+  color: var(--card-foreground);
+  border-radius: 0.75rem;
+  overflow: hidden;
+  padding-bottom: 1rem;
+}
+.agent-prompt {
+  margin: 1.5rem;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  background: var(--accent);
+  color: var(--accent-foreground);
+  font-size: 0.9375rem;
+}
+.agent-response {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0 1.5rem 1.5rem;
+}
+.agent-response > svg {
+  color: var(--primary);
+  flex-shrink: 0;
+  margin-top: 0.25rem;
+}
+.agent-response > div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.9375rem;
+}
+.agent-response p {
+  color: var(--muted-foreground);
+}
+.agent-files {
+  padding-inline: 1.5rem;
+}
+.agent-files > div {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding-block: 0.75rem;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.875rem;
+}
+.agent-files > div > span {
+  margin-left: auto;
+  color: var(--muted-foreground);
+}
+.agent-files > div > svg {
+  flex-shrink: 0;
+  color: var(--success);
+}
+.agent-files code {
+  font-size: 0.875rem;
+}
+.security-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+.security-list > div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.security-list h3 {
+  font-size: 1.0625rem;
+}
+.security-list p {
+  color: var(--muted-foreground);
+  font-size: 0.9375rem;
+}
+.security-links {
+  border-top: 1px solid var(--border);
+  padding: 1rem;
+  display: flex;
+  justify-content: space-around;
+  gap: 1rem;
+  font-size: 0.875rem;
+}
+.security-links a:hover {
+  text-decoration: underline;
+}
+.hosting-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+.hosting-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 2rem;
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  background: var(--card);
+  color: var(--card-foreground);
+}
+.hosting-card > svg {
+  width: 2rem;
+  height: 2rem;
+  color: var(--primary);
+}
+.hosting-card > p {
+  color: var(--muted-foreground);
+}
+.hosting-card .quiet-note {
+  margin-top: auto;
+  padding-top: 0.5rem;
+}
+.comparison-scroll {
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+}
+.comparison-table {
+  width: 100%;
+  min-width: 44rem;
+  border-collapse: collapse;
+  font-size: 0.9375rem;
+  background: var(--card);
+  color: var(--card-foreground);
+}
+.comparison-table :is(th, td) {
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid var(--border);
+}
+.comparison-table tr:last-child :is(th, td) {
+  border-bottom: none;
+}
+.comparison-table th {
+  text-align: left;
+  font-weight: 500;
+}
+.comparison-table thead th {
+  font-weight: 600;
+  vertical-align: top;
+}
+.comparison-table thead th span {
+  display: block;
+  font-weight: 400;
+  font-size: 0.875rem;
+  color: var(--muted-foreground);
+}
+.comparison-table tr > :nth-child(2) {
+  background: var(--accent);
+  color: var(--accent-foreground);
+}
+.comparison-table tr > :not(:first-child) {
+  text-align: center;
+}
+.comparison-table td > svg {
+  margin-inline: auto;
+}
+.comparison-yes {
+  color: var(--success);
+  stroke-width: 2.5;
+}
+.comparison-no {
+  color: var(--muted-foreground);
+  opacity: 0.4;
+}
+.comparison-notes {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--muted-foreground);
+}
+.comparison-notes p:first-child {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+.comparison-notes a {
+  text-decoration: underline;
+  text-underline-offset: 0.2rem;
+}
+.code-panel {
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  overflow: hidden;
+  background: var(--card);
+  color: var(--card-foreground);
+  min-width: 0;
+}
+.code-panel pre {
+  padding: 1.5rem;
+  overflow-x: auto;
+  font-size: 0.875rem;
+  line-height: 1.8;
+}
+.code-comment {
+  color: var(--muted-foreground);
+}
+.code-panel > a {
+  display: block;
+  padding: 1rem;
+  border-top: 1px solid var(--border);
+  color: var(--primary);
+  font-size: 0.875rem;
+}
+.maker-card {
+  display: grid;
+  grid-template-columns: 15rem 1fr;
+  gap: 4rem;
+  align-items: center;
+  padding: 3rem;
+  border-block: 1px solid var(--border);
+}
+.maker-portrait {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+.maker-portrait img {
+  border-radius: 1rem;
+  width: 100%;
+  height: auto;
+  filter: grayscale(1);
+}
+.maker-card .section-copy {
+  max-width: 37rem;
+}
+.maker-card h2 {
+  font-size: clamp(2rem, 3vw, 2.75rem);
+}
+.final-cta {
+  background: var(--accent);
+  color: var(--accent-foreground);
+  border: 1px solid color-mix(in srgb, var(--primary) 20%, var(--border));
+  padding: 4rem 1.5rem;
+  border-radius: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+  text-align: center;
+}
+.final-cta > svg {
+  width: 2rem;
+  height: 2rem;
+}
+.final-cta .marketing-actions {
+  justify-content: center;
+}
+.marketing-skip-link {
+  position: absolute;
+  top: 0.5rem;
+  left: 1rem;
+  transform: translateY(-200%);
+  padding: 0.75rem 1rem;
+  background: var(--primary);
+  color: var(--primary-foreground);
+  z-index: 40;
+}
+.marketing-skip-link:focus {
+  transform: translateY(0);
+}
+.marketing-header {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  border-bottom: 1px solid var(--border);
+}
+.marketing-header-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  min-height: 4.5rem;
+}
+.marketing-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1.375rem;
+  font-weight: 650;
+  letter-spacing: -0.04em;
+}
+.marketing-logo > svg {
+  color: var(--primary);
+}
+.marketing-header-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.marketing-nav {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  font-size: 0.875rem;
+  color: var(--muted-foreground);
+}
+.marketing-nav a {
+  display: inline-flex;
+  padding-block: 0.75rem;
+  white-space: nowrap;
+}
+.marketing-nav a:hover {
+  color: var(--primary);
+}
+.marketing-nav a[aria-current='page'] {
+  color: var(--foreground);
+  font-weight: 600;
+}
+.marketing-footer {
+  border-top: 1px solid var(--border);
+  padding-block: 3rem 1.5rem;
+}
+.footer-grid {
+  display: grid;
+  grid-template-columns: 2fr repeat(3, 1fr);
+  gap: 2rem;
+}
+.footer-brand {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1rem;
+}
+.footer-brand p {
+  color: var(--muted-foreground);
+  max-width: 17rem;
+  font-size: 0.9375rem;
+}
+.footer-column {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.75rem;
+  font-size: 0.875rem;
+}
+.footer-column h2 {
+  font-size: 0.875rem;
+  letter-spacing: 0;
+  font-weight: 600;
+}
+.footer-column a {
+  color: var(--muted-foreground);
+}
+.footer-column a:hover {
+  color: var(--primary);
+  text-decoration: underline;
+}
+.footer-bottom {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding-top: 2rem;
+  margin-top: 2rem;
+  border-top: 1px solid var(--border);
+  color: var(--muted-foreground);
+  font-size: 0.875rem;
+}
+.pricing-hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+  padding-block: 5rem 3rem;
+  text-align: center;
+}
+.pricing-hero h1 {
+  font-size: clamp(3rem, 6vw, 5rem);
+  letter-spacing: -0.06em;
+  font-weight: 550;
+}
+.pricing-hero h1 span {
+  color: var(--primary);
+}
+.pricing-hero > p:not(.eyebrow) {
+  color: var(--muted-foreground);
+  max-width: 37rem;
+  font-size: 1.125rem;
+}
+.pricing-grid {
+  display: grid;
+  grid-template-columns: 1.25fr 1fr;
+  gap: 1.5rem;
+  align-items: stretch;
+  max-width: 62rem;
+  margin-inline: auto;
+  width: 100%;
+}
+.pricing-card {
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1.5rem;
+  background: var(--card);
+  color: var(--card-foreground);
+}
+.pricing-card-main {
+  border-color: var(--primary);
+}
+.price {
+  font-size: 5rem;
+  font-weight: 550;
+  line-height: 1;
+  letter-spacing: -0.07em;
+}
+.price > span {
+  color: var(--muted-foreground);
+  font-size: 1rem;
+  letter-spacing: 0;
+}
+.pricing-card > p {
+  color: var(--muted-foreground);
+}
+.pricing-card h2 {
+  font-size: 1.75rem;
+}
+.pricing-card .marketing-actions {
+  margin-top: auto;
+}
+.pricing-card > a:last-child {
+  margin-top: auto;
+}
+.pricing-costs {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.pricing-costs > div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+.pricing-costs h3 {
+  font-size: 1rem;
+}
+.pricing-costs p {
+  color: var(--muted-foreground);
+  font-size: 0.9375rem;
+}
+.pricing-faq {
+  max-width: 52rem;
+}
+.pricing-faq [data-slot='accordion-trigger'] {
+  font-size: 1rem;
+  padding-block: 1.5rem;
+}
+.pricing-faq [data-slot='accordion-content'] {
+  color: var(--muted-foreground);
+  font-size: 1rem;
+}
+@keyframes signal-travel {
+  from {
+    stroke-dashoffset: 380;
+  }
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+@keyframes gentle-float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-5px);
+  }
+}
+@keyframes draw-line {
+  from {
+    stroke-dashoffset: 220;
+  }
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+@keyframes gentle-spark {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.12);
+  }
+}
+@keyframes notification-in {
+  from {
+    transform: translateY(8px);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+@media (max-width: 1100px) {
+  .marketing-header-top {
+    flex-wrap: wrap;
+    gap: 0;
+    padding-top: 0.75rem;
+  }
+  .marketing-nav {
+    width: 100%;
+    order: 3;
+    overflow-x: auto;
+  }
+  .marketing-hero {
+    gap: 2rem;
+  }
+  .preview-body {
+    grid-template-columns: 1fr;
+  }
+  .preview-nav {
+    display: none;
+  }
+  .split-section {
+    gap: 2.5rem;
+  }
+  .content-toolbar > .small-label {
+    display: none;
+  }
+  .agent-files > div > span {
+    display: none;
+  }
+}
+@media (max-width: 760px) {
+  .marketing-shell {
+    width: calc(100% - 2rem);
+  }
+  .marketing-section {
+    padding-block: 3rem;
+    gap: 2rem;
+  }
+  .marketing-hero {
+    grid-template-columns: 1fr;
+    padding-block: 3rem;
+    gap: 2.5rem;
+  }
+  .hero-copy h1 {
+    font-size: clamp(3.5rem, 11vw, 5rem);
+  }
+  .hero-visual {
+    max-width: 34rem;
+    width: 100%;
+    margin-inline: auto;
+  }
+  .community-preview {
+    transform: none;
+  }
+  .preview-body {
+    grid-template-columns: 8rem 1fr;
+  }
+  .preview-nav {
+    display: flex;
+  }
+  .canary-notice {
+    flex-wrap: wrap;
+    padding: 1rem;
+    gap: 0.75rem;
+  }
+  .canary-notice > div {
+    flex: 1;
+    min-width: 12rem;
+  }
+  .canary-notice > a {
+    width: 100%;
+  }
+  .outcomes {
+    grid-template-columns: 1fr;
+    padding-block: 2rem;
+    gap: 1.5rem;
+  }
+  .outcomes > div {
+    gap: 0.5rem;
+  }
+  .feature-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .feature-card {
+    padding: 1.25rem;
+  }
+  .feature-art {
+    min-height: 9rem;
+  }
+  .feature-card-wide {
+    grid-column: span 2;
+  }
+  .split-section,
+  .hosting-grid,
+  .pricing-grid {
+    grid-template-columns: 1fr;
+  }
+  .section-heading-row {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+  .three-up {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+  .window-bar .window-dots {
+    display: none;
+  }
+  .maker-card {
+    grid-template-columns: 1fr;
+    padding: 2rem 0;
+    gap: 2rem;
+  }
+  .maker-portrait {
+    align-items: flex-start;
+  }
+  .maker-portrait img {
+    width: 10rem;
+    height: 10rem;
+  }
+  .footer-grid {
+    grid-template-columns: repeat(3, 1fr);
+    gap: 2rem 1rem;
+  }
+  .footer-brand {
+    grid-column: 1 / -1;
+  }
+  .footer-brand p {
+    max-width: 24rem;
+  }
+  .pricing-hero {
+    padding-block: 3rem 2rem;
+  }
+}
+@media (max-width: 480px) {
+  .feature-grid {
+    grid-template-columns: 1fr;
+  }
+  .feature-card-wide {
+    grid-column: auto;
+  }
+  .preview-body {
+    grid-template-columns: 1fr;
+  }
+  .preview-nav {
+    display: none;
+  }
+  .post-tag {
+    display: none;
+  }
+  .content-table > div {
+    grid-template-columns: minmax(0, 1fr) 5rem;
+  }
+  .content-table > div > span:last-child {
+    display: none;
+  }
+  .content-flow {
+    display: none;
+  }
+  .content-table > div > span:first-child {
+    gap: 0.375rem;
+  }
+  .content-table > div > span:first-child > svg {
+    display: none;
+  }
+  .pricing-card,
+  .hosting-card {
+    padding: 1.5rem;
+  }
+  .footer-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+  .marketing-actions {
+    width: 100%;
+  }
+  .marketing-actions > a {
+    flex: 1;
+    white-space: nowrap;
+  }
+  .marketing-nav {
+    gap: 1.25rem;
+  }
+  .agent-preview .window-bar .small-label {
+    display: none;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .marketing *,
+  .marketing *::before,
+  .marketing *::after {
+    animation: none !important;
+    transition: none !important;
+    scroll-behavior: auto !important;
+  }
+  .marketing .community-preview {
+    transform: none;
+  }
+}

--- a/apps/web/src/site/marketing/metadata.ts
+++ b/apps/web/src/site/marketing/metadata.ts
@@ -1,0 +1,108 @@
+import { pageHead } from '#/lib/page-head'
+import { HOME_DESCRIPTION, HOME_TITLE } from '#/site/home/metadata'
+
+import { REPOSITORY_URL } from './links'
+
+export const SITE_ORIGIN = 'https://vitnode.com'
+
+const pages = {
+  home: { title: HOME_TITLE, description: HOME_DESCRIPTION, path: '/' },
+  pricing: {
+    title: 'Pricing — Free & Open Source',
+    description:
+      'VitNode is free, MIT-licensed community software. Get the full framework with no licence fees. See what is included and plan for your own hosting and services.',
+    path: '/pricing',
+  },
+}
+
+export const marketingHead = (page: keyof typeof pages) => {
+  const { title, description, path } = pages[page]
+  const url = new URL(path, SITE_ORIGIN).href
+  const socialTitle = `${title} - VitNode`
+  const head = pageHead({
+    title,
+    description,
+    robots: 'index, follow',
+    openGraph: { title: socialTitle, description, type: 'website' },
+  })
+
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'WebSite',
+        '@id': `${SITE_ORIGIN}/#website`,
+        name: 'VitNode',
+        url: `${SITE_ORIGIN}/`,
+        inLanguage: 'en',
+      },
+      {
+        '@type': 'WebPage',
+        '@id': `${url}#webpage`,
+        url,
+        name: socialTitle,
+        description,
+        inLanguage: 'en',
+        isPartOf: { '@id': `${SITE_ORIGIN}/#website` },
+        about: { '@id': `${SITE_ORIGIN}/#software` },
+      },
+      {
+        '@type': 'SoftwareSourceCode',
+        '@id': `${SITE_ORIGIN}/#software`,
+        name: 'VitNode',
+        description: HOME_DESCRIPTION,
+        codeRepository: REPOSITORY_URL,
+        license: `${REPOSITORY_URL}/blob/canary/LICENSE`,
+        programmingLanguage: 'TypeScript',
+        version: '2.0 canary',
+        isAccessibleForFree: true,
+        author: {
+          '@type': 'Person',
+          name: 'Maciej Balcerzak',
+          url: 'https://github.com/aXenDeveloper',
+        },
+      },
+      ...(page === 'pricing'
+        ? [
+            {
+              '@type': 'BreadcrumbList',
+              itemListElement: [
+                {
+                  '@type': 'ListItem',
+                  position: 1,
+                  name: 'Home',
+                  item: `${SITE_ORIGIN}/`,
+                },
+                {
+                  '@type': 'ListItem',
+                  position: 2,
+                  name: 'Pricing',
+                  item: url,
+                },
+              ],
+            },
+          ]
+        : []),
+    ],
+  }
+
+  return {
+    ...head,
+    links: [{ rel: 'canonical', href: url }],
+    meta: [
+      ...head.meta,
+      { property: 'og:url', content: url },
+      { property: 'og:site_name', content: 'VitNode' },
+      { property: 'og:locale', content: 'en_US' },
+      { name: 'twitter:card', content: 'summary' },
+      { name: 'twitter:title', content: socialTitle },
+      { name: 'twitter:description', content: description },
+    ],
+    scripts: [
+      {
+        type: 'application/ld+json',
+        children: JSON.stringify(structuredData).replace(/</g, '\\u003c'),
+      },
+    ],
+  }
+}

--- a/apps/web/src/site/marketing/pricing.tsx
+++ b/apps/web/src/site/marketing/pricing.tsx
@@ -1,0 +1,185 @@
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@vitnode/core/components/ui/accordion'
+import { RouteMessages } from '@vitnode/core/tanstack/i18n'
+import { RouterLink } from '@vitnode/core/tanstack/layout'
+import { ArrowRight, Check, Coffee } from 'lucide-react'
+
+import {
+  CanaryNotice,
+  MarketingActions,
+  REPOSITORY_URL,
+  SectionHeading,
+} from './shared'
+
+const faqs = [
+  {
+    question: 'Is VitNode actually free?',
+    answer:
+      'Yes. VitNode is open-source software under the MIT licence. There is no VitNode software subscription, per-member licence fee, or paid feature tier. You still pay for the infrastructure and services you choose.',
+  },
+  {
+    question: 'Can I use it for my company or a client?',
+    answer:
+      'Yes. The MIT licence allows commercial use and modification. Keep the required copyright and licence notices when distributing the software. Your client project can be as serious as you like; our pricing page doesn’t have to be.',
+  },
+  {
+    question: 'What will I need to pay for?',
+    answer:
+      'Your hosting, database, domain, and any storage, email, search, or AI services you select. Development and maintenance take time too. Costs depend on your setup and usage; VitNode does not bundle or bill for those services.',
+  },
+  {
+    question: 'Does VitNode offer a managed cloud plan?',
+    answer:
+      'Not currently. You can deploy to your own cloud account using the Vercel guide, or self-host. A compatible server is needed for the built-in WebSocket server, local uploads, and in-process cron.',
+  },
+  {
+    question: 'Is the canary ready for my live community?',
+    answer:
+      'Canary is a very early development build. Expect breaking changes, bugs, and unfinished features. Use it to explore and prototype, and assess its stability and security carefully before relying on it in production.',
+  },
+  {
+    question: 'How can I support the project?',
+    answer:
+      'Try it, report a reproducible bug, improve the docs, or contribute a plugin. Share what you are building. Helpful feedback is a pretty good currency around here.',
+  },
+]
+
+export const PricingBreadcrumb = () => (
+  <RouteMessages>
+    <span>Pricing</span>
+  </RouteMessages>
+)
+
+export const PricingPage = () => (
+  <div className="marketing" lang="en">
+    <section
+      className="marketing-shell pricing-hero"
+      aria-labelledby="pricing-title"
+    >
+      <p className="eyebrow">Pricing. A very short negotiation.</p>
+      <h1 id="pricing-title">
+        Big community energy.
+        <br />
+        <span>Zero licence fees.</span>
+      </h1>
+      <p>
+        One plan. The whole framework. No sales call standing between you and
+        your next idea.
+      </p>
+      <span className="canary-pill">
+        <Coffee size={16} aria-hidden /> Your coffee may cost more than our
+        software.
+      </span>
+    </section>
+    <section
+      className="marketing-shell marketing-section"
+      aria-label="VitNode pricing"
+    >
+      <div className="pricing-grid">
+        <article className="pricing-card pricing-card-main">
+          <span className="small-label">
+            The open-source plan · MIT licence
+          </span>
+          <h2>The whole thing.</h2>
+          <div className="price">
+            $0 <span>/ software licence</span>
+          </div>
+          <p>
+            For side projects, ambitious teams, and “what if we built…”
+            conversations.
+          </p>
+          <ul className="check-list">
+            {[
+              'Full source code, yours to change',
+              'Plugin system and Content Engine',
+              'AdminCP, member roles, and staff permissions',
+              'i18n, search, events, and caching tools',
+              'AI integrations and real-time building blocks',
+              'Commercial use and self-hosting',
+            ].map((item) => (
+              <li key={item}>
+                <Check aria-hidden />
+                {item}
+              </li>
+            ))}
+          </ul>
+          <MarketingActions LinkComponent={RouterLink} />
+          <p className="quiet-note">
+            Current canary features. Provider setup may be required. No managed
+            hosting or support SLA included.
+          </p>
+        </article>
+        <article className="pricing-card">
+          <p className="eyebrow">The part where we’re honest</p>
+          <h2>
+            Servers still enjoy
+            <br />
+            being paid.
+          </h2>
+          <p>
+            The framework is free. Running your community has its own costs.
+          </p>
+          <div className="pricing-costs">
+            <div>
+              <h3>A place to live</h3>
+              <p>Hosting, a database, a domain, and backups.</p>
+            </div>
+            <div>
+              <h3>The extras you choose</h3>
+              <p>Email, storage, search services, and AI provider usage.</p>
+            </div>
+            <div>
+              <h3>A little care and feeding</h3>
+              <p>Your development time, updates, and ongoing maintenance.</p>
+            </div>
+          </div>
+          <RouterLink
+            href="/docs/dev/deployments/self-hosted"
+            className="text-link"
+          >
+            Choose your setup <ArrowRight size={16} aria-hidden />
+          </RouterLink>
+        </article>
+      </div>
+      <CanaryNotice LinkComponent={RouterLink} />
+    </section>
+    <section
+      className="marketing-shell marketing-section pricing-faq"
+      aria-labelledby="pricing-faq-title"
+    >
+      <SectionHeading
+        eyebrow="Very fair questions"
+        title="Wait, what’s the catch?"
+        id="pricing-faq-title"
+      >
+        No mysterious asterisk. Just a few things worth knowing.
+      </SectionHeading>
+      <Accordion>
+        {faqs.map(({ question, answer }) => (
+          <AccordionItem key={question}>
+            <AccordionTrigger>{question}</AccordionTrigger>
+            <AccordionContent>{answer}</AccordionContent>
+          </AccordionItem>
+        ))}
+      </Accordion>
+    </section>
+    <section className="marketing-shell marketing-section">
+      <div className="final-cta">
+        <h2>
+          No checkout.
+          <br />
+          Just a starting point.
+        </h2>
+        <p>Build something your people will want to come back to.</p>
+        <MarketingActions LinkComponent={RouterLink} />
+        <a className="text-link" href={`${REPOSITORY_URL}/blob/canary/LICENSE`}>
+          Read the MIT licence <ArrowRight size={16} aria-hidden />
+        </a>
+      </div>
+    </section>
+  </div>
+)

--- a/apps/web/src/site/marketing/shared.tsx
+++ b/apps/web/src/site/marketing/shared.tsx
@@ -1,0 +1,67 @@
+import type { ReactNode } from 'react'
+
+import { buttonVariants } from '@vitnode/core/components/ui/button'
+import { ArrowRight, Bird, Code2 } from 'lucide-react'
+
+import type { SiteLinkComponent } from '#/site/home/site-link'
+
+import { REPOSITORY_URL } from './links'
+
+export { REPOSITORY_URL } from './links'
+
+export const MarketingActions = ({
+  LinkComponent: Link,
+}: {
+  LinkComponent: SiteLinkComponent
+}) => (
+  <div className="marketing-actions">
+    <Link className={buttonVariants({ size: 'lg' })} href="/docs/dev/setup">
+      Start building <ArrowRight size={16} aria-hidden />
+    </Link>
+    <a
+      className={buttonVariants({ size: 'lg', variant: 'outline' })}
+      href={REPOSITORY_URL}
+    >
+      <Code2 size={18} aria-hidden /> Explore GitHub
+    </a>
+  </div>
+)
+
+export const CanaryNotice = ({
+  LinkComponent: Link,
+}: {
+  LinkComponent: SiteLinkComponent
+}) => (
+  <aside className="canary-notice" aria-label="Canary release status">
+    <Bird aria-hidden />
+    <div>
+      <strong>Very early. Very canary.</strong>
+      <p>
+        This is an early development build, not a stable release. Expect bugs,
+        unfinished features, and breaking changes. Explore, experiment, and help
+        shape it before relying on it in production.
+      </p>
+    </div>
+    <Link href="/docs/dev/contribution">
+      Help it grow <ArrowRight size={16} aria-hidden />
+    </Link>
+  </aside>
+)
+
+export const SectionHeading = ({
+  children,
+  eyebrow,
+  id,
+  title,
+}: {
+  children: ReactNode
+  eyebrow: string
+  id: string
+  title: string
+}) => (
+  <div className="section-heading">
+    <p className="eyebrow">{eyebrow}</p>
+    <h2 id={id}>{title}</h2>
+    <p>{children}</p>
+  </div>
+)

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -3,6 +3,7 @@
 @import 'tw-animate-css';
 @import 'fumadocs-ui/css/neutral.css';
 @import 'fumadocs-ui/css/preset.css';
+@import './site/marketing/marketing.css';
 
 @source "../node_modules/@vitnode/core/dist/src/components";
 @source "../node_modules/@vitnode/core/dist/src/tanstack";


### PR DESCRIPTION
VitNode's homepage currently describes the framework in technical terms and gives visitors little help understanding what they can build, how it supports their team, or what the early canary release includes.

This PR introduces a complete community-focused marketing experience with playful copy and clear paths into the documentation.

## Changes

- Redesign the homepage with a responsive feature bento, a larger Content Engine card, and SVG demonstrations for i18n, caching, events, AI, search, WebSockets, plugins, and security.
- Add dedicated sections for the plugin system, AdminCP, community roles and staff permissions, AI coding agents, authentication/CAPTCHA/social sign-in, cloud and self hosting, developer setup, and Maciej's maker story.
- Add a sourced comparison against Discourse and Circle, with green/gray checks and accessible text equivalents.
- Add `/pricing`: free MIT software, practical infrastructure costs, commercial use, and FAQs.
- Share navigation and a footer across the main route layout, preserving language, theme, and account controls.
- Add a skip link, responsive layouts, light/dark colors, and reduced-motion support. SVG animations run once and finish within five seconds.
- Add unique titles/descriptions, Open Graph and Twitter text, canonical URLs, JSON-LD, `robots.txt`, and a sitemap. Marketing content renders on the server and links directly to the relevant docs.

## Canary accuracy

The copy explicitly identifies this as a very early development build. Moderator permissions exist, while a dedicated Moderator CP is not shipped. AI experiences need implementation and provider configuration. Cloud means deployment to the user's own provider account; VitNode does not currently sell managed hosting. The Vercel section calls out its built-in WebSocket, local upload, and in-process cron limitations.

Community and agent cards are labeled illustrations; the AdminCP section reuses the existing product screenshot. Competitor sources and the comparison date are linked in the page.

Marketing copy remains English. Canonicals consolidate identical locale-prefixed marketing pages to the official unprefixed URLs. The implementation notes explain how to extend this when translated copy is added.

## Validation

- Production Vite/Nitro build: passed.
- Web TypeScript check (`tsc --noEmit`): passed.
- Core and required workspace plugin compilation: passed.
- Documentation links, sitemap XML/canonical URLs, and robots sitemap reference: passed.
- `git diff --check`: passed.

Browser and end-to-end testing were not run.