### PR TITLE
fix(devices): clean up stale device records

### DIFF
--- a/packages/vitnode/src/api/models/device.test.ts
+++ b/packages/vitnode/src/api/models/device.test.ts
@@ -30,7 +30,7 @@ const AUTHORIZATION: Authorization = {
  * `storedDevice` is what a `select` on the devices table finds - `null` for "no
  * such device", which is both the no-cookie case and the forged-cookie case.
  */
-const fakeDb = (storedDevice: null | { id: number }) => {
+const fakeDb = (storedDevice: null | { id: number }, selectError?: Error) => {
   const inserts: unknown[] = [];
 
   const chain = (kind: string, table: unknown) => {
@@ -52,8 +52,16 @@ const fakeDb = (storedDevice: null | { id: number }) => {
       limit: () => self,
       returning: () => self,
       set: () => self,
-      then: async (onFulfilled: (value: unknown[]) => unknown) =>
-        await Promise.resolve(onFulfilled(rows())),
+      then: async (
+        onFulfilled: (value: unknown[]) => unknown,
+        onRejected?: (reason: unknown) => unknown,
+      ) => {
+        if (op.kind === "select" && selectError) {
+          return await Promise.resolve(onRejected?.(selectError));
+        }
+
+        return await Promise.resolve(onFulfilled(rows()));
+      },
       values: (value: unknown) => {
         if (op.table === core_sessions_known_devices) inserts.push(value);
 
@@ -79,16 +87,24 @@ const fakeDb = (storedDevice: null | { id: number }) => {
 const run = async <T>({
   act,
   cookie,
+  selectError,
   storedDevice = null,
 }: {
   act: (c: Context) => Promise<T>;
   cookie?: string;
+  selectError?: Error;
   storedDevice?: null | { id: number };
 }): Promise<{ inserts: number; result: T }> => {
-  const { db, inserts } = fakeDb(storedDevice);
+  const { db, inserts } = fakeDb(storedDevice, selectError);
   let result: T | undefined;
+  let thrownError: Error | undefined;
 
   const app = new Hono();
+  app.onError((error, c) => {
+    thrownError = error;
+
+    return c.body(null, 500);
+  });
   app.get("/", async c => {
     c.set("core", {
       authorization: AUTHORIZATION,
@@ -101,6 +117,7 @@ const run = async <T>({
   });
 
   await app.request("/", cookie ? { headers: { cookie } } : {});
+  if (thrownError) throw thrownError;
 
   return { inserts: inserts.length, result: result as T };
 };
@@ -163,6 +180,18 @@ describe("DeviceModel", () => {
 
       expect(result).toEqual({ id: 42, publicId: "known" });
       expect(inserts).toBe(0);
+    });
+
+    it("does not create a device when the existing-device lookup fails", async () => {
+      const lookupError = new Error("database unavailable");
+
+      await expect(
+        run({
+          act: async c => await new DeviceModel(c).getOrCreateDeviceId(),
+          cookie: "vitnode_device=known",
+          selectError: lookupError,
+        }),
+      ).rejects.toBe(lookupError);
     });
   });
 });

--- a/packages/vitnode/src/api/models/device.ts
+++ b/packages/vitnode/src/api/models/device.ts
@@ -69,29 +69,25 @@ export class DeviceModel {
     );
     if (!deviceIdFromCookie) return null;
 
-    try {
-      const [device] = await this.c
-        .get("db")
-        .select({ id: core_sessions_known_devices.id })
-        .from(core_sessions_known_devices)
-        .where(eq(core_sessions_known_devices.publicId, deviceIdFromCookie));
+    const [device] = await this.c
+      .get("db")
+      .select({ id: core_sessions_known_devices.id })
+      .from(core_sessions_known_devices)
+      .where(eq(core_sessions_known_devices.publicId, deviceIdFromCookie));
 
-      if (!device) return null;
+    if (!device) return null;
 
-      await this.c
-        .get("db")
-        .update(core_sessions_known_devices)
-        .set({
-          ipAddress: this.c.get("ipAddress"),
-          userAgent: this.getUserAgent(),
-          lastSeen: new Date(),
-        })
-        .where(eq(core_sessions_known_devices.publicId, deviceIdFromCookie));
+    await this.c
+      .get("db")
+      .update(core_sessions_known_devices)
+      .set({
+        ipAddress: this.c.get("ipAddress"),
+        userAgent: this.getUserAgent(),
+        lastSeen: new Date(),
+      })
+      .where(eq(core_sessions_known_devices.publicId, deviceIdFromCookie));
 
-      return { id: device.id, publicId: deviceIdFromCookie };
-    } catch {
-      return null;
-    }
+    return { id: device.id, publicId: deviceIdFromCookie };
   }
 
   /**

--- a/packages/vitnode/src/api/modules/cron/cron/clean.cron.test.ts
+++ b/packages/vitnode/src/api/modules/cron/cron/clean.cron.test.ts
@@ -1,0 +1,23 @@
+import { PgDialect } from "drizzle-orm/pg-core";
+import { drizzle } from "drizzle-orm/postgres-js";
+import { describe, expect, it } from "vitest";
+
+import { isOrphanedDevice } from "./clean.cron";
+
+describe("isOrphanedDevice", () => {
+  it("keeps devices referenced by public or admin sessions", () => {
+    const { sql } = new PgDialect().sqlToQuery(
+      isOrphanedDevice(drizzle.mock()),
+    );
+
+    expect(sql.match(/not exists/g)).toHaveLength(2);
+    expect(sql).toContain('from "core_sessions"');
+    expect(sql).toContain('from "core_admin_sessions"');
+    expect(sql).toContain(
+      '"core_sessions"."deviceId" = "core_sessions_known_devices"."id"',
+    );
+    expect(sql).toContain(
+      '"core_admin_sessions"."deviceId" = "core_sessions_known_devices"."id"',
+    );
+  });
+});

--- a/packages/vitnode/src/api/modules/cron/cron/clean.cron.ts
+++ b/packages/vitnode/src/api/modules/cron/cron/clean.cron.ts
@@ -1,9 +1,35 @@
-import { lt } from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
+
+import { eq, lt, notExists, sql } from "drizzle-orm";
+
+import type { EnvVitNode } from "@/api/middlewares/global.middleware";
 
 import { buildCron } from "@/api/lib/cron";
 import { core_admin_sessions } from "@/database/admins";
-import { core_sessions } from "@/database/sessions";
+import {
+  core_sessions,
+  core_sessions_known_devices,
+} from "@/database/sessions";
 import { core_users_forgot_password } from "@/database/users";
+
+export const isOrphanedDevice = (
+  db: Pick<EnvVitNode["Variables"]["db"], "select">,
+): SQL => {
+  const hasNoPublicSessions = notExists(
+    db
+      .select({ one: sql`1` })
+      .from(core_sessions)
+      .where(eq(core_sessions.deviceId, core_sessions_known_devices.id)),
+  );
+  const hasNoAdminSessions = notExists(
+    db
+      .select({ one: sql`1` })
+      .from(core_admin_sessions)
+      .where(eq(core_admin_sessions.deviceId, core_sessions_known_devices.id)),
+  );
+
+  return sql`${hasNoPublicSessions} and ${hasNoAdminSessions}`;
+};
 
 export const cleanCron = buildCron({
   name: "clean",
@@ -19,6 +45,8 @@ export const cleanCron = buildCron({
       await tx
         .delete(core_admin_sessions)
         .where(lt(core_admin_sessions.expiresAt, new Date()));
+
+      await tx.delete(core_sessions_known_devices).where(isOrphanedDevice(tx));
 
       // Delete expired forgot password tokens
       await tx


### PR DESCRIPTION
## Summary

- stop treating database failures during device lookup as a missing device, which previously allowed sign-in to mint another device record
- remove orphaned known-device rows after expired public and admin sessions are cleaned
- keep device rows that are still referenced by either session type
- add regression coverage for lookup failures and the orphan predicate

## Why

`core_sessions_known_devices` could grow indefinitely because the hourly cleanup deleted expired sessions but never their now-unreferenced device rows. Additionally, `DeviceModel.getExistingDeviceId()` caught every database error and returned `null`; `getOrCreateDeviceId()` then interpreted that as an unknown device and attempted to create a replacement.

The cleanup deliberately does not merge devices by IP address or User-Agent because those values are not stable or unique enough for a security-sensitive session list.

## Verification

- `pnpm test` — 309 files, 5,596 tests passed
- `pnpm exec tsc --noEmit -p tsconfig.json`
- ESLint on all changed files
- `git diff --check`